### PR TITLE
cqfd: do not handle semicolon comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ The `.cqfdrc` file supports Unix shell comments; the words after the character
 `#` are ignored up to the end of line. A comment cannot be set in the first
 line, and right after a section.
 
+Note: The traditional .ini comment, i.e. words after the character `;` are not
+supported anymore since cqfd6.
+
 ### Using build flavors
 
 In some cases, it may be desirable to build the project using variations of the

--- a/cqfd
+++ b/cqfd
@@ -116,7 +116,9 @@ cfg_parser() {
 	mapfile -t ini <"$1"                                 # convert to line-array
 	ini=("${ini[@]//[/\\[}")                             # escape [
 	ini=("${ini[@]//]/\\]}")                             # escape ]
-	ini=("${ini[@]//;*/}")                               # remove comments with ;
+	if [ "$COMPAT" -lt 6 ]; then
+		ini=("${ini[@]//;*/}")                       # remove comments with ;
+	fi
 	ini=("${ini[@]/$'\t'=/=}")                           # remove tabs before =
 	ini=("${ini[@]/=$'\t'/=}")                           # remove tabs after =
 	ini=("${ini[@]/\ =/=}")                              # remove space before =

--- a/tests/03-cqfdrc_error
+++ b/tests/03-cqfdrc_error
@@ -126,5 +126,15 @@ else
 	jtest_result fail
 fi
 
+cp -f .cqfdrc.orig .cqfdrc
+sed -i -e "/[build]/,/^$/s,^command=.*$,command='true; echo \"It works!\"'," .cqfdrc
+
+jtest_prepare "cqfdrc does not strip semicolons in command"
+if CQFD_COMPAT=6 "$cqfd" init && CQFD_COMPAT=6 "$cqfd" | grep "It works!" ; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
 # restore initial .cqfdrc
 mv -f .cqfdrc.orig .cqfdrc


### PR DESCRIPTION
The .ini files uses the semicolon for comments. Also, that exact same character is one of the shell control operator for list of pipelines.

The hacky parser is not smart enough to make the distinction if a semicolon is an .ini comment or if it is a shell control operator.

It considers every semicolon character as a .ini comment, and it removes the remaining characters till the EOL (including the semicolon), even if they are part of a list of pipeline.

As a consequence, it cuts off the list of pipelines if the command= values contain a semicolon character, and it results in running the left-hand only.

This stops to handle the semicolon comments to avoid amputating the list of pipelines controled by semicolons that are set in values of the command= properties.

Note: The parser converts the .ini file to bash; as a consequence, the shell comments do not affect the parsing, as long as the hashmark does not break the syntax **AND** if it not put at the end of the section line.