### PR TITLE
cqfd: do not remove whitespaces around assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Here is a sample `.cqfdrc` file:
     files='README.FOOINC output/images/sdcard.img'
     archive='cqfd-%Gh.tar.xz'
 
+Note: The property and its value must be stick to the equal sign, without using
+whitespaces since cqfd6: i.e. `foo =	bar` is invalid.
+
 ### Comments
 
 The `.cqfdrc` file supports Unix shell comments; the words after the character

--- a/cqfd
+++ b/cqfd
@@ -118,11 +118,11 @@ cfg_parser() {
 	ini=("${ini[@]//]/\\]}")                             # escape ]
 	if [ "$COMPAT" -lt 6 ]; then
 		ini=("${ini[@]//;*/}")                       # remove comments with ;
+		ini=("${ini[@]/$'\t'=/=}")                   # remove tabs before =
+		ini=("${ini[@]/=$'\t'/=}")                   # remove tabs after =
+		ini=("${ini[@]/\ =/=}")                      # remove space before =
+		ini=("${ini[@]/=\ /=}")                      # remove space after =
 	fi
-	ini=("${ini[@]/$'\t'=/=}")                           # remove tabs before =
-	ini=("${ini[@]/=$'\t'/=}")                           # remove tabs after =
-	ini=("${ini[@]/\ =/=}")                              # remove space before =
-	ini=("${ini[@]/=\ /=}")                              # remove space after =
 	ini=("${ini[@]/#\\[/$'\n}\nfunction cfg_section_'}") # convert section to function (1)
 	ini=("${ini[@]/%\\]/ { :}")                          # convert section to function (2)
 	ini+=("}")                                           # add the last brace

--- a/tests/03-cqfdrc_error
+++ b/tests/03-cqfdrc_error
@@ -90,7 +90,14 @@ cp -f .cqfdrc.orig .cqfdrc
 echo "foo	=bar" >>.cqfdrc
 
 jtest_prepare "cqfdrc with tabulation before should pass"
-if "$cqfd" run true; then
+if CQFD_COMPAT=5 "$cqfd" run true; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+jtest_prepare "cqfdrc with tabulation before should not pass"
+if ! "$cqfd" run true; then
 	jtest_result pass
 else
 	jtest_result fail
@@ -100,7 +107,14 @@ cp -f .cqfdrc.orig .cqfdrc
 echo "foo=	bar" >>.cqfdrc
 
 jtest_prepare "cqfdrc with tabulation after should pass"
-if "$cqfd" run true; then
+if CQFD_COMPAT=5 "$cqfd" run true; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+jtest_prepare "cqfdrc with tabulation after should not pass"
+if ! "$cqfd" run true; then
 	jtest_result pass
 else
 	jtest_result fail
@@ -110,7 +124,14 @@ cp -f .cqfdrc.orig .cqfdrc
 echo "foo =bar" >>.cqfdrc
 
 jtest_prepare "cqfdrc with space before should pass"
-if "$cqfd" run true; then
+if CQFD_COMPAT=5 "$cqfd" run true; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+jtest_prepare "cqfdrc with space before should not pass"
+if ! "$cqfd" run true; then
 	jtest_result pass
 else
 	jtest_result fail
@@ -120,7 +141,14 @@ cp -f .cqfdrc.orig .cqfdrc
 echo "foo= bar" >>.cqfdrc
 
 jtest_prepare "cqfdrc with space after should pass"
-if "$cqfd" run true; then
+if CQFD_COMPAT=5 "$cqfd" run true; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+jtest_prepare "cqfdrc with space after should not pass"
+if ! "$cqfd" run true; then
 	jtest_result pass
 else
 	jtest_result fail


### PR DESCRIPTION
Both .ini and shell grammars use the equal sign for assignment (=). The sign delimitates the property and the variable name from their value.

Whitespaces on both side of the sign are allowed in the .ini world while they are not in the shell grammar.

Here is a property statement in an .ini file:

	property = value

And, a variable assigment in shell:

	variable=value

The hacky parser[1] transforms an .ini file into a shell script: a section is a shell function, and a property is a variable.

As a consequence, the parser must ensure to remove the whitespaces wrapping the sign = if any. It uses a shell substitution to strip off the whitespaces on both side of the **first occurence** of the equal sign.

Unfortunatly, the parser is not smart enough to make the disctinction if the **first occurence** of the equal with surrounding whitespaces is the sign delimitating the property and its value or if it is part of the value.

Therefore, it may result in stripping off the whitespaces in the value if there is no whitespaces arround the assigment sign as in the example below.

The following command property,

	command='if test "$container" = "podman"; then echo podman; else
exit 1; fi'

Become the command variable:

	command='if test "$container"="podman"; then echo podman; else
exit 1; fi'

And the command always evaluates to true as the expression is a single string "$container"='podman' (evaluated to =podman) that is a non-null expression and thus true as per test(1):

	test EXPRESSION

	The parser needs to strip An  omitted  EXPRESSION defaults  to
	false. Otherwise, EXPRESSION is true or false and sets exit
	status.

See:

	gportay@archlinux ~ $ test "$container"="'podman' && echo okay
	okay

This stops to strip off the whitespaces to avoid altering the variable values if the .cqfdrc does not use spaces around the equal sign.

Note: This is workaround as:

	command = 'if test "$container" = "podman"; then echo podman; else

Or as:

	command='if test "$container"  =  "podman"; then echo podman; else

[1]: https://ajdiaz.wordpress.com/2008/02/09/bash-ini-parser/