### PR TITLE
 Add warning if run command has multiple arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,17 @@ default build command as configured in `.cqfdrc`, use:
 
     $ cqfd
 
-Alternatively, you may want to specify a custom command to be
+Alternatively, you may want to specify a single custom command to be
 executed from inside the build container.
 
-    $ cqfd run make clean
-    $ cqfd run "make linux-dirclean && make foobar-dirclean"
-
-The `run` command is broken in some situations, and it is then recommended to
-use `exec` for a single command, `shell -c` for a command composed with shell
-grammar, or `shell` to run a shell script with or without arguments:
-
     $ cqfd exec make clean
+
+Or custom commands composed with shell grammar:
+
     $ cqfd shell -c "make linux-dirclean && make foobar-dirclean"
+
+Or run a shell script with arguments:
+
     $ cqfd shell ./build.sh debug
 
 When `cqfd` is running, the current directory is mounted by Docker
@@ -169,7 +168,7 @@ Furthermore, when using `image` the `Dockerfile` is **not** necessary as well.
 
 ### The [build] section
 
-#### `cqfd run`
+#### `cqfd`
 
 `command`: the command string to be executed when cqfd is invoked. This
 string will be passed as an argument to a classical `sh -c "commands"`,

--- a/cqfd
+++ b/cqfd
@@ -1128,6 +1128,14 @@ while [ $# -gt 0 ]; do
 
 		# Run alternate command
 		build_command="$*"
+
+		# Display a warning message if using run with multiple arguments
+		if [ "$#" -ne 1 ]; then
+			warn "command run with multiple arguments is ambigous," \
+			     "please consider the commands exec or shell instead:"
+			echo "               cqfd exec $*" >&2
+			echo "               cqfd shell -c \"$*\"" >&2
+		fi
 		break
 		;;
 	sh|ash|dash|bash|ksh|zsh|csh|tcsh|fish|shell)

--- a/cqfd
+++ b/cqfd
@@ -1123,6 +1123,13 @@ while [ $# -gt 0 ]; do
 			fi
 
 			build_command+=" $*"
+
+			# Display a warning message if using run -c with multiple arguments
+			if [ "$#" -gt 1 ]; then
+				warn "command run -c shall support a single argument," \
+				     "please consider the command run -c instead:"
+				echo "               cqfd run -c \"$*\"" >&2
+			fi
 			break
 		fi
 


### PR DESCRIPTION
The command `run command_string` is ambiguous, and cqfd should tell the user to switch to `cqfd exec PROGRAM [ARGUMENTS...]` if the `command_string` is a single command or to `cqfd shell -c "command_string"` if the `command_string` is a list of command.

More information in 344969c0de765faba5a22c8cb470e4efe63b2047.