### PR TITLE
cqfd: optionize init command

### DIFF
--- a/bash-completion
+++ b/bash-completion
@@ -99,7 +99,7 @@ _cqfd() {
 		return
 	fi
 
-	local opts="-C -w -d -f -b -q --release --platform -v --version -h --help"
+	local opts="-C -w -d -f -b -q --reinit --release --platform -v --version -h --help"
 	if [[ "$cur" == -* ]]; then
 		COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 		return

--- a/cqfd
+++ b/cqfd
@@ -38,6 +38,7 @@ usage() {
 Usage: $PROGNAME [OPTIONS] [COMMAND] [COMMAND OPTIONS] [ARGUMENTS]
 
 Options:
+    --reinit             Reinitialize build container.
     --release            Release software.
     --platform <target>  Set target platform.
     -f <file>            Use file as config file (default .cqfdrc).
@@ -1016,6 +1017,7 @@ load_config() {
 	fi
 }
 
+has_to_init=false
 has_to_release=false
 while [ $# -gt 0 ]; do
 	case "$1" in
@@ -1115,6 +1117,9 @@ while [ $# -gt 0 ]; do
 		quiet=true
 		export BUILDKIT_PROGRESS=quiet
 		;;
+	--reinit)
+		has_to_init=true
+		;;
 	--release)
 		has_to_release=true
 		;;
@@ -1209,6 +1214,10 @@ fi
 
 if [ -z "$build_command" ]; then
 	die ".cqfdrc: Missing or empty build.command property!"
+fi
+
+if $has_to_init; then
+	docker_pull_or_build
 fi
 
 docker_run "$build_command"

--- a/cqfd.1.adoc
+++ b/cqfd.1.adoc
@@ -65,6 +65,9 @@ Command options for run:
 
 == OPTIONS
 
+*--reinit*:
+	Reinitialize build container.
+
 *--release*::
 	Release software.
 


### PR DESCRIPTION
This adds the option --reinit that allows to cqfd init from an empty command and the command run, and to cqfd init from the commands shell and exec:

	cqfd [--reinit] [run] [command_string].
	cqfd [--reinit] shell [arguments]
	cqfd [--reinit] exec  program [arguments]