### PR TITLE
Support for compatibility level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Makefile for cqfd6
 
 PREFIX?=/usr/local
+COMPAT?=$(shell bash cqfd --compatibility)
 
 .PHONY: all help doc install uninstall test tests check
 
@@ -19,8 +20,8 @@ doc: cqfd.1.gz cqfdrc.5.gz
 
 install:
 	install -d $(DESTDIR)$(PREFIX)/bin/
-	install -m 0755 cqfd $(DESTDIR)$(PREFIX)/bin/cqfd6
-	ln -sf cqfd6 $(DESTDIR)$(PREFIX)/bin/cqfd
+	install -m 0755 cqfd $(DESTDIR)$(PREFIX)/bin/cqfd$(COMPAT)
+	ln -sf cqfd$(COMPAT) $(DESTDIR)$(PREFIX)/bin/cqfd
 	for i in linux-amd64 linux-arm linux-arm64 linux-ppc64le linux-riscv64 linux-s390x; do \
 		ln -sf cqfd6 $(DESTDIR)$(PREFIX)/bin/$$i-cqfd; \
 	done
@@ -65,7 +66,7 @@ user-%:
 	$(MAKE) $* PREFIX=$$HOME/.local
 
 test tests:
-	@$(MAKE) -C tests GIT_DIR=$(CURDIR)/.git
+	@$(MAKE) -C tests GIT_DIR=$(CURDIR)/.git CQFD_COMPAT=$(COMPAT)
 
 check:
 	shellcheck cqfd

--- a/bash-completion
+++ b/bash-completion
@@ -112,7 +112,7 @@ _cqfd() {
 	fi
 
 	local opts="-C --directory -w --working-directory -d --cqfd-directory -f --cqfdrc-file -b --build -q --quiet --reinit --release --platform"
-	local cmds="--init --deinit --ls --gc --flavors --exec --run --shell -v --version -h --help"
+	local cmds="--init --deinit --ls --gc --flavors --exec --run --shell -v --version --compatibility -h --help"
 	COMPREPLY=( $(compgen -W "$cmds $opts" -- "$cur") )
 } &&
 complete -F _cqfd cqfd linux-amd64-cqfd linux-arm-cqfd linux-arm64-cqfd linux-ppc64le-cqfd linux-riscv64-cqfd linux-s390x-cqfd cqfd6

--- a/cqfd
+++ b/cqfd
@@ -21,8 +21,24 @@
 set -e
 set -o pipefail
 
+compat() {
+	local compat
+
+	compat="$0"
+	compat="${compat##*/}"
+	compat="${compat#*cqfd}"
+	if [[ ! "$compat" ]]
+	then
+		# shellcheck disable=SC2034
+		IFS=. read -r M m _ <<<"$1"
+		compat="$M"
+	fi
+	echo "$compat"
+}
+
 PROGNAME=$(basename "$0")
 VERSION=6
+COMPAT="${CQFD_COMPAT:-$(compat "$VERSION")}"
 cqfd_user="${USER:-builder}"
 cqfd_home="${HOME:-/home/$cqfd_user}"
 cqfd_shell="${CQFD_SHELL:-/bin/sh}"
@@ -61,6 +77,7 @@ Options:
                          Target a specific build flavor.
     -q or --quiet        Turn on quiet mode.
     -v or --version      Show version.
+    --compatibility      Show compatibility level.
     --verbose            Increase the script's verbosity.
     -h or --help         Show this help text.
 
@@ -125,7 +142,8 @@ warn_deprecated_command() {
 	local cmd
 
 	# Deprecated command messages disabled
-	if [ "$CQFD_NO_DEPRECATED_COMMAND_WARNING" = true ]; then
+	if [ "$CQFD_NO_DEPRECATED_COMMAND_WARNING" = true ] || \
+	   [ "$COMPAT" -lt 6 ]; then
 		return
 	fi
 
@@ -1045,6 +1063,7 @@ load_config() {
 	fi
 }
 
+debug Compatibility level "$COMPAT"
 has_to_init=false
 has_to_release=false
 while [ $# -gt 0 ]; do
@@ -1089,6 +1108,10 @@ while [ $# -gt 0 ]; do
 
 		# Output version
 		echo "$VERSION"
+		exit
+		;;
+	--compatibility)
+		echo "$COMPAT"
 		exit
 		;;
 	--verbose)

--- a/tests/00-setup
+++ b/tests/00-setup
@@ -4,7 +4,8 @@
 
 . "$(dirname "$0")/jtest.inc" "$1"
 mkdir -p "$TDIR/.cqfd/docker"
-cp -a ../cqfd "$TDIR/.cqfd/"
+cp -a ../cqfd "$TDIR/.cqfd/cqfd$CQFD_COMPAT"
+ln -sf "cqfd$CQFD_COMPAT" "$TDIR/.cqfd/cqfd"
 cp -a test_data/. "$TDIR/."
 cqfd="$TDIR/.cqfd/cqfd"
 


### PR DESCRIPTION
As every piece of software, cqfd is subject to breaking changes, either
because of features are fixed, or because of features are deprecated.

And, cqfd may need to maintain compatibility with the previous versions.

The .cqfdrc file is usually committed in the projects using it; that
file is closely related to a specific version of cqfd.

To overcome the breaking changes, multiple versions of cqfd can be
installed in the same system; every cqfd verion is suffixed by its
compatibility level. For example:
 - cqfd5 (5.x.y)
 - cqfd6 (6)
 - cqfd2026 (2026)?
 - ... as long as the compatibility level increases

cqfd is a symlink to the latest (or a specific) version.

Also, cqfd can maintain breaking changes in its code by checking the
compatibility level at runtime, either using the environment CQFD_COMPAT
(ex. export CQFD_COMPAT=5) or using the filename (ex. cqfd -> cqfd6).

cqfd6 has renamed the commands using double hyphen prefix since commit
https://github.com/gportay/cqfd6/commit/29e4c36f0047bb0505c83b4a71be8917a4d2406e, and it has added deprecated
warning messages since commit https://github.com/gportay/cqfd6/commit/003828ad1d55640ad62171ed9063acf056808ee7
if using former commands (i.e. without double hyphen prefix).

The upcoming release of cqfd5 (5.8.0) supports both commands and will
not warn about using former commands.

	$ cqfd5 run "uname -m"
	x86_64

	$ cqfd6 run "uname -m"
	cqfd: warning: command run is deprecated, please consider the command instead: cqfd --run 'uname -m'
	x86_64

This adds support for compatibility level, the cqfd's compatibility
level is set by the environment (CQFD_COMPAT) or deduced from script
filename.