### PR TITLE
cqfd: allow relative and absolute path with -d option

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -513,8 +513,14 @@ EOF
 ## locate_project_dir() - locate directory with .cqfd upwards
 # stdout: the path to the .cqfd parent directory
 locate_project_dir() {
-	local search_dir="$PWD"
+	local search_dir
 
+	if $has_custom_cqfddir; then
+		realpath "$cqfddir/.."
+		return
+	fi
+
+	search_dir="$PWD"
 	while [ "$search_dir" != "/" ]; do
 		if [ -d "$search_dir"/"$cqfddir" ]; then
 			realpath "$search_dir"
@@ -529,8 +535,14 @@ locate_project_dir() {
 ## load_config() - load build settings from cqfdrc
 # $1: optional "flavor" of the build, is a suffix of command
 load_config() {
+	# get the project directory
 	if ! cqfd_project_dir=$(locate_project_dir); then
 		die ".cqfd directory not found in directory tree"
+	fi
+
+	# unless using '-d other_cqfddir', use base directory located above
+	if ! $has_custom_cqfddir; then
+		cqfddir="$cqfd_project_dir/$cqfddir"
 	fi
 
 	# unless using '-f other_cqfdrc', use base directory located above
@@ -617,7 +629,7 @@ load_config() {
 	# shellcheck disable=SC2154
 	release_tar_opts="$tar_options"
 
-	dockerfile="$cqfd_project_dir/$cqfddir/${build_distro:-docker}/Dockerfile"
+	dockerfile="$cqfddir/${build_distro:-docker}/Dockerfile"
 	if [ ! -f "$dockerfile" ]; then
 		die "$dockerfile not found"
 	fi
@@ -636,6 +648,7 @@ load_config() {
 	fi
 }
 
+has_custom_cqfddir=false
 has_custom_cqfdrc=false
 has_to_release=false
 has_alternate_command=false
@@ -669,6 +682,7 @@ while [ $# -gt 0 ]; do
 		;;
 	-d)
 		shift
+		has_custom_cqfddir=true
 		cqfddir="$1"
 		;;
 	-f)

--- a/tests/05-cqfd_init_alt_ext
+++ b/tests/05-cqfd_init_alt_ext
@@ -27,10 +27,33 @@ else
 fi
 
 ################################################################################
-# 'cqfd init' using alternate filenames in an external directory should work
+# 'cqfd init' using alternate filenames in an external directory using filenames
+# should work
 ################################################################################
-jtest_prepare "cqfd init using alternate filenames in an external directory should work"
+jtest_prepare "cqfd init using alternate filenames in an external directory using filenames should work"
 if "$cqfd" -C "$extdir" -d cqfd -f cqfdrc init; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+################################################################################
+# 'cqfd init' using alternate filenames in an external directory using absolute
+# filenames should work
+################################################################################
+jtest_prepare "cqfd init using alternate filenames in an external directory using relative filenames should work"
+if "$cqfd" -d "$extdir/cqfd" -f "$extdir/cqfdrc" init; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+################################################################################
+# 'cqfd init' using alternate filenames in an external directory using absolute
+# filenames should work
+################################################################################
+jtest_prepare "cqfd init using alternate filenames in an external directory using absolute filenames should work"
+if "$cqfd" -d "$PWD/$extdir/cqfd" -f "$PWD/$extdir/cqfdrc" init; then
 	jtest_result pass
 else
 	jtest_result fail


### PR DESCRIPTION
The option -f allows absolute .cqfdrc while the option -d allows
directory name "only".

The directory name given to the option -d is used by the function
locate_project_dir() to locate the project directory (i.e. the .cqfd
parent directory). The project directory searches for the directory name
backward starting by the current working directory up to root.

Important: At that point, relative directory works, but it is not
suitable to use more path components than a (single) filename. Using
cqfd -d subdir/to/dot-cqfd works file but the function searches for the
directory "subdir/to/dot-cqfd" and this is not suitable is using option
-C to change directory; cqfd -C subdir/to -d dot-cqfd is preferable.

This allows giving relative and absolute path to option -d to specify
the path to the .cqfd directory to use, by hacking the function
locate_project_dir() to return the parent directory of the .cqfd set by
the option -d, and by prepending the working directory to the cqfddir
variable if the option -d is unset.