### PR TITLE
cqfd: add -w option to set working directory

### DIFF
--- a/bash-completion
+++ b/bash-completion
@@ -29,7 +29,7 @@ _cqfd() {
 	_init_completion || return
 
 	case $prev in
-	-C|-d)
+	-C|-w|-d)
 		_filedir -d
 		return
 		;;
@@ -95,7 +95,7 @@ _cqfd() {
 		return
 	fi
 
-	local opts="-C -d -f -b -q --release -V --version -h --help"
+	local opts="-C -w -d -f -b -q --release -V --version -h --help"
 	if [[ "$cur" == -* ]]; then
 		COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 		return

--- a/cqfd
+++ b/cqfd
@@ -42,7 +42,9 @@ Options:
     --release            Release software.
     -f <file>            Use file as config file (default .cqfdrc).
     -d <directory>       Use directory as cqfd directory (default .cqfd).
-    -C <directory>       Use the specified working directory.
+    -w <directory>       Use directory as working directory (default parent of
+                         .cqfd).
+    -C <directory>       Change to the specified working directory.
     -b <flavor_name>     Target a specific build flavor.
     -q                   Turn on quiet mode.
     -v or --version      Show version.
@@ -549,7 +551,12 @@ docker_run() {
 	fi
 
 	# Bind mount the project directory
-	args+=(--volume "$cqfd_project_dir:$cqfd_project_dir")
+	local workdir
+	if ! workdir="$(realpath "$build_workdir")" ||
+	   [ ! -d "$workdir" ]; then
+		die "$workdir: Missing or not a directory!"
+	fi
+	args+=(--volume "$workdir:$workdir")
 
 	# Create and bind mount the entrypoint
 	tmp_entrypoint=$(mktemp /tmp/cqfd-entrypoint.XXXXXX)
@@ -770,24 +777,43 @@ locate_project_dir() {
 # $1: optional "flavor" of the build, is a suffix of command
 load_config() {
 	# get the project directory
-	if ! cqfd_project_dir=$(locate_project_dir); then
+	local project_dir
+	if ! project_dir=$(locate_project_dir); then
 		die ".cqfd: Missing project directory!"
+	fi
+
+	# unless using '-w other_workdir', use base directory located above
+	if ! $has_custom_workdir; then
+		workdir="$project_dir"
+	fi
+	# make an absolute path and check if it is a directory
+	if ! workdir="$(realpath "$workdir")" || \
+	   [ ! -d "$workdir" ]; then
+		die ".cqfd: Missing or not a directory!"
 	fi
 
 	# unless using '-d other_cqfddir', use base directory located above
 	if ! $has_custom_cqfddir; then
-		cqfddir="$cqfd_project_dir/$cqfddir"
+		cqfddir="$project_dir/$cqfddir"
+	fi
+	# make an absolute path and check if it is a directory
+	if ! cqfddir="$(realpath "$cqfddir")" || \
+	   [ ! -d "$cqfddir" ]; then
+		die ".cqfd: Missing or not a directory!"
 	fi
 
 	# unless using '-f other_cqfdrc', use base directory located above
 	if ! $has_custom_cqfdrc; then
-		cqfdrc="$cqfd_project_dir/$cqfdrc"
+		cqfdrc="$project_dir/$cqfdrc"
+	fi
+	cqfdrc="$(realpath "$cqfdrc")"
+	# make an absolute path and check if it is a file
+	if ! cqfdrc="$(realpath "$cqfdrc")" || \
+	   [ ! -f "$cqfdrc" ]; then
+		die ".cqfdrc: Missing or not a file!"
 	fi
 
-	if [ ! -f "$cqfdrc" ]; then
-		die ".cqfdrc: Missing project file!"
-	fi
-
+	# parse cqfdrc file
 	if ! cfg_parser "$cqfdrc"; then
 		die ".cqfdrc: Invalid ini-file!"
 	fi
@@ -847,6 +873,8 @@ load_config() {
 
 	# shellcheck disable=SC2128
 	build_flavors="$flavors"
+	# shellcheck disable=SC2154
+	build_workdir="$workdir"
 	# shellcheck disable=SC2154
 	build_command="$command"
 	# shellcheck disable=SC2154
@@ -926,6 +954,7 @@ load_config() {
 	fi
 }
 
+has_custom_workdir=false
 has_custom_cqfddir=false
 has_custom_cqfdrc=false
 has_to_release=false
@@ -970,6 +999,11 @@ while [ $# -gt 0 ]; do
 	-b)
 		shift
 		flavor="$1"
+		;;
+	-w)
+		shift
+		has_custom_workdir=true
+		workdir="$1"
 		;;
 	-d)
 		shift

--- a/cqfd.1.adoc
+++ b/cqfd.1.adoc
@@ -71,8 +71,11 @@ Command options for run:
 *-d DIR*::
 	Use directory as cqfd directory (default _.cqfd_).
 
+*-w DIR*::
+	Use directory as working directory (default parent of _.cqfd_).
+
 *-C DIR*::
-	Use the specified working directory.
+	Change to the specified working directory.
 
 *-b STRING*::
 	Target a specific build flavor.

--- a/tests/05-cqfd_run_alt_ext
+++ b/tests/05-cqfd_run_alt_ext
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# validate the behavior of run with working directory
+
+set -o pipefail
+
+. "$(dirname "$0")"/jtest.inc "$1"
+
+cd "$TDIR/" || exit 1
+
+################################################################################
+# First, move every local cqfd files into an external directory and use
+# alternate filenames
+################################################################################
+workdir="workingdir"
+mkdir -p "$workdir"
+mv .cqfd "$workdir/.cqfd"
+mv .cqfdrc "$workdir/.cqfdrc"
+cqfd="$TDIR/$workdir/.cqfd/cqfd"
+cd "$workdir" || exit 1
+
+################################################################################
+# 'cqfd run' using nonexistent working directory should fail
+################################################################################
+jtest_prepare "cqfd run using inexistant working directory should fail"
+if ! "$cqfd" -w "nonexistentdir" run; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+################################################################################
+# 'cqfd run' using default working directory should work
+################################################################################
+jtest_prepare "cqfd run using default working directory should work"
+if "$cqfd" run "stat -c '%u' .." | grep -q "0"; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+################################################################################
+# 'cqfd run' using alternate working directory should work
+################################################################################
+jtest_prepare "cqfd run using working directory should work"
+if "$cqfd" -w ".." run "stat -c '%u' .." | grep -q "$UID"; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+################################################################################
+# restore local cqfd files
+################################################################################
+cd "$OLDPWD" || exit 1
+mv "$workdir/.cqfdrc" .cqfdrc
+mv "$workdir/.cqfd" .cqfd
+rmdir -p "$workdir"


### PR DESCRIPTION
cqfd bind-mounts the parent directory of .cqfd by default. It may be useful to map another directory in certain circumstances.

This adds the option -w to set the working directory to bind-mount the specified directory instead of the parent of the .cqfd directory.