### PR TITLE
tests: 05-cqfd-init-custom-image: improve testing

### DIFF
--- a/tests/05-cqfd_init_custom_image
+++ b/tests/05-cqfd_init_custom_image
@@ -51,7 +51,7 @@ else
 fi
 
 jtest_prepare "cqfd init works using custom_img_name=$custom_img_name"
-if "$cqfd" init && "$cqfd" | grep -qE "Ubuntu 24.04(.[[:digit:]]+)? LTS"; then
+if "$cqfd" init; then
 	jtest_result pass
 else
 	jtest_result fail
@@ -59,6 +59,13 @@ fi
 
 jtest_prepare "$cqfd_docker registry contains image named: $custom_img_name"
 if "$cqfd_docker" inspect "$custom_img_name" &>/dev/null; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+jtest_prepare "cqfd runs created image $custom_img_name"
+if "$cqfd" | grep -qE "Ubuntu 24.04(.[[:digit:]]+)? LTS"; then
 	jtest_result pass
 else
 	jtest_result fail

--- a/tests/05-cqfd_init_custom_image
+++ b/tests/05-cqfd_init_custom_image
@@ -31,11 +31,10 @@ EOF
 mkdir -p .cqfd/docker
 echo "FROM ubuntu:24.04" >.cqfd/docker/Dockerfile
 
-jtest_prepare "$cqfd_docker registry contains NO image named: $custom_image_1"
-if ! "$cqfd_docker" inspect "$custom_image_1" &>/dev/null; then
-	jtest_result pass
-else
-	jtest_result fail
+jtest_log info "$cqfd_docker registry contains NO image named: $custom_image_1"
+if "$cqfd_docker" inspect "$custom_image_1" &>/dev/null; then
+	jtest_log fatal "$custom_image_1 already present before test"
+	"$cqfd_docker" rmi "$custom_image_1"
 fi
 
 jtest_prepare "cqfd init works using custom_img_name=$custom_image_1"

--- a/tests/05-cqfd_init_custom_image
+++ b/tests/05-cqfd_init_custom_image
@@ -9,27 +9,15 @@ cqfd_docker="${CQFD_DOCKER:-docker}"
 cd "$TDIR/" || exit 1
 
 cp -f .cqfd/docker/Dockerfile .cqfd/docker/Dockerfile.old
+cp -f .cqfd/docker/Dockerfile.init_custom_image .cqfd/docker/Dockerfile
 cp -f .cqfdrc .cqfdrc.old
+cp -f cqfdrc-custom_image .cqfdrc
+custom_image_1="cqfd_test_custom_image_$RANDOM$RANDOM"
+sed -i -e "s!^custom_img_name=.*\$!custom_img_name='$custom_image_1'!" .cqfdrc
 
 ################################################################################
 # 'cqfd init' with custom_img_name
 ################################################################################
-custom_image_1="cqfd_test_custom_image_1_$RANDOM$RANDOM"
-
-# Test .cqfdrc
-cat >.cqfdrc <<EOF
-[project]
-org="cqfd"
-name="custom-image"
-custom_img_name="$custom_image_1"
-
-[build]
-command="true"
-EOF
-
-# Test dockerfile
-echo "FROM ubuntu:24.04" >.cqfd/docker/Dockerfile
-
 jtest_log info "$cqfd_docker registry contains NO image named: $custom_image_1"
 if "$cqfd_docker" inspect "$custom_image_1" &>/dev/null; then
 	jtest_log fatal "$custom_image_1 already present before test"
@@ -50,9 +38,11 @@ else
 	jtest_result fail
 fi
 
-################################################################################
 # cleanup
-################################################################################
 "$cqfd_docker" rmi "$custom_image_1"
+
+################################################################################
+# Restore initial .cqfdrc and Dockerfile
+################################################################################
 mv -f .cqfdrc.old .cqfdrc
 mv -f .cqfd/docker/Dockerfile.old .cqfd/docker/Dockerfile

--- a/tests/05-cqfd_init_custom_image
+++ b/tests/05-cqfd_init_custom_image
@@ -6,10 +6,10 @@
 cqfd="$TDIR/.cqfd/cqfd"
 cqfd_docker="${CQFD_DOCKER:-docker}"
 
-# create a temporary directory
-TEST_DIR=$(mktemp -d -t cqfd-test-XXXXXX)
+cd "$TDIR/" || exit 1
 
-cd "$TEST_DIR/" || exit 1
+cp -f .cqfd/docker/Dockerfile .cqfd/docker/Dockerfile.old
+cp -f .cqfdrc .cqfdrc.old
 
 ################################################################################
 # 'cqfd init' with custom_img_name
@@ -28,7 +28,6 @@ command="true"
 EOF
 
 # Test dockerfile
-mkdir -p .cqfd/docker
 echo "FROM ubuntu:24.04" >.cqfd/docker/Dockerfile
 
 jtest_log info "$cqfd_docker registry contains NO image named: $custom_image_1"
@@ -55,4 +54,5 @@ fi
 # cleanup
 ################################################################################
 "$cqfd_docker" rmi "$custom_image_1"
-rm -rf "$TEST_DIR"
+mv -f .cqfdrc.old .cqfdrc
+mv -f .cqfd/docker/Dockerfile.old .cqfd/docker/Dockerfile

--- a/tests/05-cqfd_init_custom_image
+++ b/tests/05-cqfd_init_custom_image
@@ -33,7 +33,7 @@ else
 fi
 
 ################################################################################
-# 'cqfd init' with custom_img_name
+# 'cqfd init' creates custom_img_name
 ################################################################################
 custom_img_name="cqfd_test_custom_image_$RANDOM$RANDOM"
 sed -i -e "s!^custom_img_name=.*\$!custom_img_name='$custom_img_name'!" .cqfdrc
@@ -50,15 +50,9 @@ else
 	jtest_result fail
 fi
 
-jtest_prepare "cqfd init works using custom_img_name=$custom_img_name"
-if "$cqfd" init; then
-	jtest_result pass
-else
-	jtest_result fail
-fi
-
-jtest_prepare "$cqfd_docker registry contains image named: $custom_img_name"
-if "$cqfd_docker" inspect "$custom_img_name" &>/dev/null; then
+jtest_prepare "cqfd init creates image $custom_img_name from Dockerfile"
+if "$cqfd" init && \
+   "$cqfd_docker" inspect "$custom_img_name" &>/dev/null; then
 	jtest_result pass
 else
 	jtest_result fail
@@ -70,7 +64,6 @@ if "$cqfd" | grep -qE "Ubuntu 24.04(.[[:digit:]]+)? LTS"; then
 else
 	jtest_result fail
 fi
-
 # cleanup
 "$cqfd_docker" rmi "$custom_img_name"
 

--- a/tests/05-cqfd_init_custom_image
+++ b/tests/05-cqfd_init_custom_image
@@ -12,34 +12,34 @@ cp -f .cqfd/docker/Dockerfile .cqfd/docker/Dockerfile.old
 cp -f .cqfd/docker/Dockerfile.init_custom_image .cqfd/docker/Dockerfile
 cp -f .cqfdrc .cqfdrc.old
 cp -f cqfdrc-custom_image .cqfdrc
-custom_image_1="cqfd_test_custom_image_$RANDOM$RANDOM"
-sed -i -e "s!^custom_img_name=.*\$!custom_img_name='$custom_image_1'!" .cqfdrc
+custom_img_name="cqfd_test_custom_image_$RANDOM$RANDOM"
+sed -i -e "s!^custom_img_name=.*\$!custom_img_name='$custom_img_name'!" .cqfdrc
 
 ################################################################################
 # 'cqfd init' with custom_img_name
 ################################################################################
-jtest_log info "$cqfd_docker registry contains NO image named: $custom_image_1"
-if "$cqfd_docker" inspect "$custom_image_1" &>/dev/null; then
-	jtest_log fatal "$custom_image_1 already present before test"
-	"$cqfd_docker" rmi "$custom_image_1"
+jtest_log info "$cqfd_docker registry contains NO image named: $custom_img_name"
+if "$cqfd_docker" inspect "$custom_img_name" &>/dev/null; then
+	jtest_log info "$cqfd_docker registry contains image named: $custom_img_name, removing..."
+	"$cqfd_docker" rmi "$custom_img_name"
 fi
 
-jtest_prepare "cqfd init works using custom_img_name=$custom_image_1"
+jtest_prepare "cqfd init works using custom_img_name=$custom_img_name"
 if "$cqfd" init && "$cqfd" run "true"; then
 	jtest_result pass
 else
 	jtest_result fail
 fi
 
-jtest_prepare "$cqfd_docker registry contains image named: $custom_image_1"
-if "$cqfd_docker" inspect "$custom_image_1" &>/dev/null; then
+jtest_prepare "$cqfd_docker registry contains image named: $custom_img_name"
+if "$cqfd_docker" inspect "$custom_img_name" &>/dev/null; then
 	jtest_result pass
 else
 	jtest_result fail
 fi
 
 # cleanup
-"$cqfd_docker" rmi "$custom_image_1"
+"$cqfd_docker" rmi "$custom_img_name"
 
 ################################################################################
 # Restore initial .cqfdrc and Dockerfile

--- a/tests/05-cqfd_init_custom_image
+++ b/tests/05-cqfd_init_custom_image
@@ -2,6 +2,8 @@
 #
 # validate the behavior of custom image
 
+set -o pipefail
+
 . "$(dirname "$0")"/jtest.inc "$1"
 cqfd="$TDIR/.cqfd/cqfd"
 cqfd_docker="${CQFD_DOCKER:-docker}"
@@ -12,12 +14,29 @@ cp -f .cqfd/docker/Dockerfile .cqfd/docker/Dockerfile.old
 cp -f .cqfd/docker/Dockerfile.init_custom_image .cqfd/docker/Dockerfile
 cp -f .cqfdrc .cqfdrc.old
 cp -f cqfdrc-custom_image .cqfdrc
-custom_img_name="cqfd_test_custom_image_$RANDOM$RANDOM"
+
+################################################################################
+# 'cqfd' pulls custom_img_name
+################################################################################
+custom_img_name="ubuntu:16.04"
 sed -i -e "s!^custom_img_name=.*\$!custom_img_name='$custom_img_name'!" .cqfdrc
+if "$cqfd_docker" inspect "$custom_img_name" &>/dev/null; then
+	jtest_log info "$cqfd_docker registry contains image named: $custom_img_name, removing..."
+	"$cqfd_docker" rmi "$custom_img_name"
+fi
+
+jtest_prepare "cqfd pulls image $custom_img_name from registry"
+if "$cqfd" | grep -qE "Ubuntu 16.04(.[[:digit:]]+)? LTS"; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
 
 ################################################################################
 # 'cqfd init' with custom_img_name
 ################################################################################
+custom_img_name="cqfd_test_custom_image_$RANDOM$RANDOM"
+sed -i -e "s!^custom_img_name=.*\$!custom_img_name='$custom_img_name'!" .cqfdrc
 jtest_log info "$cqfd_docker registry contains NO image named: $custom_img_name"
 if "$cqfd_docker" inspect "$custom_img_name" &>/dev/null; then
 	jtest_log info "$cqfd_docker registry contains image named: $custom_img_name, removing..."
@@ -25,7 +44,7 @@ if "$cqfd_docker" inspect "$custom_img_name" &>/dev/null; then
 fi
 
 jtest_prepare "cqfd init works using custom_img_name=$custom_img_name"
-if "$cqfd" init && "$cqfd" run "true"; then
+if "$cqfd" init && "$cqfd" | grep -qE "Ubuntu 24.04(.[[:digit:]]+)? LTS"; then
 	jtest_result pass
 else
 	jtest_result fail

--- a/tests/05-cqfd_init_custom_image
+++ b/tests/05-cqfd_init_custom_image
@@ -43,6 +43,13 @@ if "$cqfd_docker" inspect "$custom_img_name" &>/dev/null; then
 	"$cqfd_docker" rmi "$custom_img_name"
 fi
 
+jtest_prepare "cqfd fails pulling inexistant image $custom_img_name from registry"
+if ! "$cqfd"; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
 jtest_prepare "cqfd init works using custom_img_name=$custom_img_name"
 if "$cqfd" init && "$cqfd" | grep -qE "Ubuntu 24.04(.[[:digit:]]+)? LTS"; then
 	jtest_result pass

--- a/tests/test_data/.cqfd/docker/Dockerfile.init_custom_image
+++ b/tests/test_data/.cqfd/docker/Dockerfile.init_custom_image
@@ -1,0 +1,1 @@
+FROM ubuntu:24.04

--- a/tests/test_data/cqfdrc-custom_image
+++ b/tests/test_data/cqfdrc-custom_image
@@ -1,0 +1,7 @@
+[project]
+org="cqfd"
+name="custom-image"
+custom_img_name="cqfd_test_custom_image"
+
+[build]
+command="true"

--- a/tests/test_data/cqfdrc-custom_image
+++ b/tests/test_data/cqfdrc-custom_image
@@ -1,7 +1,7 @@
 [project]
 org="cqfd"
 name="custom-image"
-custom_img_name="cqfd_test_custom_image"
+custom_img_name="ubuntu:16.04"
 
 [build]
-command="true"
+command="grep ^PRETTY_NAME /etc/os-release"


### PR DESCRIPTION
This PR updates rewrites the testing of `custom_img_name` feature.

Note: It tests the pulling of the `custom_img_name` from distant registries.