### PR TITLE
debian: Dockerfile: use tag bootworm

### DIFF
--- a/.cqfd/deb/Dockerfile
+++ b/.cqfd/deb/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:bookworm
 ENV DPKG_FRONTEND=noninteractive
 RUN apt-get -y update && apt-get -y install asciidoctor bash-completion build-essential debhelper devscripts pkgconf shellcheck
 CMD ["dpkg-buildpackage", "-us", "-uc"]


### PR DESCRIPTION
Debian 13 (Trixie) was relesed today[1].

This tags bookworm instead of latest (trixie) as the base image for the Dockerfile.

Note: The GitHub Workflow uses bookworm.

[1]: https://www.debian.org/releases/trixie/