### PR TITLE
README.md: fix trailing whitespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,14 +298,14 @@ defined container.
 
 Example:
 
-    fred@host:~/project$ cat get-container-pretty-name.sh 
+    fred@host:~/project$ cat get-container-pretty-name.sh
     #!/usr/bin/env -S cqfd shell
     if ! test -e /.dockerenv; then
         exit 1
     fi
     source /etc/os-release
     echo "$PRETTY_NAME"
-    fred@host:~/projet$ ./get-container-pretty-name.sh 
+    fred@host:~/projet$ ./get-container-pretty-name.sh
     Debian GNU/Linux 12 (bookworm)
 
 ### Use cqfd as a standard shell for binaries


### PR DESCRIPTION
This fixes commit 47b5c324a9fe4738d0cdef5a3e5bc6d4abd469bd.