### PR TITLE
tests: create temporary files and directories in TDIR

### DIFF
--- a/tests/01-cqfd_init
+++ b/tests/01-cqfd_init
@@ -22,9 +22,8 @@ fi
 ################################################################################
 # 'cqfd init' with a nonexistent Dockerfile should fail
 ################################################################################
-cqfdrc_old=$(mktemp)
 jtest_prepare "init with a nonexisting dockerfile shall fail"
-cp -f .cqfdrc "$cqfdrc_old"
+cp -f .cqfdrc .cqfdrc.old
 sed -i -e "s/\[build\]/[build]\ndistro='thisshouldfail'/" .cqfdrc
 if ! "$cqfd" init; then
 	jtest_result pass
@@ -42,8 +41,8 @@ if "$cqfd" init; then
 else
 	jtest_result fail
 fi
-# restore cqfdrc
-mv -f "$cqfdrc_old" .cqfdrc
+# restore initial .cqfdrc
+mv -f .cqfdrc.old .cqfdrc
 
 ################################################################################
 # 'cqfd init' with same uid/gid dummy user should pass

--- a/tests/03-cqfd_error
+++ b/tests/03-cqfd_error
@@ -24,19 +24,3 @@ if ! "$cqfd" invalid_arg_should_fail; then
 else
 	jtest_result fail
 fi
-
-################################################################################
-# Running cqfd without a .cqfdrc file in the current directory shall fail
-################################################################################
-jtest_prepare "'cqfd run' with no config file shall fail"
-empty_dir=$(mktemp -d)
-pushd "$empty_dir" >/dev/null || exit 1
-if ! "$cqfd" run true; then
-	jtest_result pass
-else
-	jtest_result fail
-fi
-popd >/dev/null || exit 1
-
-# cleanup
-rm -rf "$empty_dir"

--- a/tests/03-cqfd_help
+++ b/tests/03-cqfd_help
@@ -9,12 +9,11 @@ cqfd="$TDIR/.cqfd/cqfd"
 # 'cqfd help' shall be an accepted command
 ################################################################################
 jtest_prepare "cqfd help shall exit normally"
-TEST=$(mktemp)
-if "$cqfd" help >"$TEST"; then
+if "$cqfd" help >"$TDIR/usage"; then
 	jtest_result pass
 else
 	jtest_result fail
-	rm -f "$TEST"
+	rm -f "$TDIR/usage"
 fi
 
 ################################################################################
@@ -23,9 +22,9 @@ fi
 jtest_prepare "cqfd help shall produce an help message"
 # Those words shall be present in the output
 for word in Usage Options Commands; do
-	if ! grep -q "^$word:" "$TEST"; then
+	if ! grep -q "^$word:" "$TDIR/usage"; then
 		jtest_log error "cannot find $word in help message"
-		rm -f "$TEST"
+		rm -f "$TDIR/usage"
 		missing=1
 		break
 	fi
@@ -36,4 +35,5 @@ else
 	jtest_result fail
 fi
 
-rm -f "$TEST"
+# cleanup
+rm -f "$TDIR/usage"

--- a/tests/03-cqfd_version
+++ b/tests/03-cqfd_version
@@ -9,8 +9,7 @@ cqfd="$TDIR/.cqfd/cqfd"
 # 'cqfd version' shall be an accepted command
 ################################################################################
 jtest_prepare "cqfd version shall exit normally"
-TEST=$(mktemp)
-if "$cqfd" version >"$TEST"; then
+if "$cqfd" version >"$TDIR/version"; then
 	jtest_result pass
 else
 	jtest_result fail
@@ -21,7 +20,7 @@ fi
 # 'cqfd version' shall produce a version message
 ################################################################################
 jtest_prepare "cqfd version shall produce a version string"
-if grep -qE "^[0-9.]+(-[a-z]+)?\$" "$TEST"; then
+if grep -qE "^[0-9.]+(-[a-z]+)?\$" "$TDIR/version"; then
 	jtest_result pass
 else
 	jtest_log error "not a version message"
@@ -29,4 +28,5 @@ else
 	jtest_result fail
 fi
 
-rm -f "$TEST"
+# cleanup
+rm -f "$TDIR/version"

--- a/tests/03-cqfdrc_error
+++ b/tests/03-cqfdrc_error
@@ -9,8 +9,7 @@ cqfd="$TDIR/.cqfd/cqfd"
 
 cd "$TDIR/" || exit 1
 
-cqfdrc_old=$(mktemp)
-cp -f .cqfdrc "$cqfdrc_old"
+cp -f .cqfdrc .cqfdrc.old
 
 echo -n "" >.cqfdrc
 
@@ -87,7 +86,7 @@ else
 	jtest_result fail
 fi
 
-cp -f "$cqfdrc_old" .cqfdrc
+cp -f .cqfdrc.old .cqfdrc
 echo "foo	=bar" >>.cqfdrc
 
 jtest_prepare "cqfdrc with tabulation before should pass"
@@ -97,7 +96,7 @@ else
 	jtest_result fail
 fi
 
-cp -f "$cqfdrc_old" .cqfdrc
+cp -f .cqfdrc.old .cqfdrc
 echo "foo=	bar" >>.cqfdrc
 
 jtest_prepare "cqfdrc with tabulation after should pass"
@@ -107,7 +106,7 @@ else
 	jtest_result fail
 fi
 
-cp -f "$cqfdrc_old" .cqfdrc
+cp -f .cqfdrc.old .cqfdrc
 echo "foo =bar" >>.cqfdrc
 
 jtest_prepare "cqfdrc with space before should pass"
@@ -117,7 +116,7 @@ else
 	jtest_result fail
 fi
 
-cp -f "$cqfdrc_old" .cqfdrc
+cp -f .cqfdrc.old .cqfdrc
 echo "foo= bar" >>.cqfdrc
 
 jtest_prepare "cqfdrc with space after should pass"
@@ -127,4 +126,5 @@ else
 	jtest_result fail
 fi
 
-mv -f "$cqfdrc_old" .cqfdrc
+# restore initial .cqfdrc
+mv -f .cqfdrc.old .cqfdrc

--- a/tests/05-cqfd_init_flavor
+++ b/tests/05-cqfd_init_flavor
@@ -13,8 +13,7 @@ cd "$TDIR/" || exit 1
 ################################################################################
 # 'cqfd init' with different flavor makes a different container
 ################################################################################
-cqfdrc_old=$(mktemp)
-cp -f .cqfdrc "$cqfdrc_old"
+cp -f .cqfdrc .cqfdrc.old
 sed -i -e "s/\[foo\]/[foo]\ndistro='centos'/" .cqfdrc
 
 jtest_prepare "cqfd init using '$flavor' flavor"
@@ -24,6 +23,8 @@ if "$cqfd" -b "$flavor" init &&
 else
 	jtest_result fail
 fi
+# restore initial .cqfdrc
+mv -f .cqfdrc.old .cqfdrc
 
 ################################################################################
 # 'cqfd init' with invalid flavor should fail
@@ -39,8 +40,6 @@ fi
 ################################################################################
 # 'cqfd init' without flavor generates our regular container
 ################################################################################
-mv -f "$cqfdrc_old" .cqfdrc
-
 jtest_prepare "cqfd init without flavor"
 if "$cqfd" init &&
    "$cqfd" run "grep '^NAME=' /etc/*release" | grep -q 'NAME="Ubuntu"'; then

--- a/tests/05-cqfd_run_config
+++ b/tests/05-cqfd_run_config
@@ -55,5 +55,5 @@ for i in 0 1 2 3; do
 	rm -f "$test_file"
 done
 
-# restore for further tests
+# restore initial .cqfdrc
 mv -f "$confdir"/mycqfdrc .cqfdrc

--- a/tests/05-cqfd_run_dockerfile
+++ b/tests/05-cqfd_run_dockerfile
@@ -20,7 +20,7 @@ else
 	jtest_result fail
 fi
 
-# restore Dockerfile
+# restore initial Dockerfile
 mv -f .cqfd/docker/Dockerfile.orig .cqfd/docker/Dockerfile
 jtest_log info "restore container"
 if ! "$cqfd" init; then

--- a/tests/05-cqfd_run_extra_groups
+++ b/tests/05-cqfd_run_extra_groups
@@ -10,9 +10,6 @@ cqfd_docker="${CQFD_DOCKER:-docker}"
 
 cd "$TDIR/" || exit 1
 
-cqfdrc_old=$(mktemp)
-cp -f .cqfdrc "$cqfdrc_old"
-
 ################################################################################
 # 'cqfd run' should add extra_groups provided by an environment variable
 ################################################################################
@@ -35,6 +32,7 @@ jtest_prepare "'cqfd run' should add config's extra_groups to the local user"
 if [ "$USER" = "runner" ] || [ "$cqfd_docker" = "podman" ]; then
 	jtest_result skip
 else
+	cp -f .cqfdrc .cqfdrc.old
 	echo 'user_extra_groups="docker newgroup:12345"' >>.cqfdrc
 	output=$("$cqfd" run groups | grep docker | grep newgroup)
 	if [ -n "$output" ]; then
@@ -42,6 +40,6 @@ else
 	else
 		jtest_result fail
 	fi
+	# restore initial .cqfdrc
+	mv -f .cqfdrc.old .cqfdrc
 fi
-
-mv -f "$cqfdrc_old" .cqfdrc

--- a/tests/05-cqfd_run_home_env_var
+++ b/tests/05-cqfd_run_home_env_var
@@ -10,9 +10,6 @@ cqfd_docker="${CQFD_DOCKER:-docker}"
 
 cd "$TDIR/" || exit 1
 
-cqfdrc_old=$(mktemp)
-cp -f .cqfdrc "$cqfdrc_old"
-
 ################################################################################
 # 'cqfd run' sets HOME environment variable for the local user
 ################################################################################
@@ -96,7 +93,8 @@ fi
 jtest_prepare "run doesn't override HOME env when set via docker_run_args"
 val1="value-$RANDOM"
 val2="value-$RANDOM"
-cat "$cqfdrc_old" - <<EOF >.cqfdrc
+cp -f .cqfdrc .cqfdrc.old
+cat .cqfdrc.old - <<EOF >.cqfdrc
 docker_run_args="--env FOO=$val1 --env HOME=$val2"
 EOF
 # shellcheck disable=SC2016
@@ -113,7 +111,7 @@ fi
 ################################################################################
 jtest_prepare "run doesn't override HOME env when the only entry in docker_run_args"
 val1="value-$RANDOM"
-cat "$cqfdrc_old" - <<EOF >.cqfdrc
+cat .cqfdrc.old - <<EOF >.cqfdrc
 docker_run_args="--env HOME=$val1"
 EOF
 # shellcheck disable=SC2016
@@ -131,7 +129,7 @@ fi
 jtest_prepare "run doesn't confuse JAVA_HOME and the like with HOME"
 val1="value-$RANDOM"
 val2="value-$RANDOM"
-cat "$cqfdrc_old" - <<EOF >.cqfdrc
+cat .cqfdrc.old - <<EOF >.cqfdrc
 docker_run_args="--env JAVA_HOME=$val1 --env HOME=$val2"
 EOF
 # shellcheck disable=SC2016
@@ -143,6 +141,6 @@ else
 fi
 
 ################################################################################
-# restore .cqfdrc
+# restore initial .cqfdrc
 ################################################################################
-mv -f "$cqfdrc_old" .cqfdrc
+mv -f .cqfdrc.old .cqfdrc

--- a/tests/05-cqfd_run_su_or_sudo_backend
+++ b/tests/05-cqfd_run_su_or_sudo_backend
@@ -73,7 +73,7 @@ else
 fi
 
 ################################################################################
-# Restore initial Dockerfile.
+# Restore initial Dockerfile
 ################################################################################
 mv -f .cqfd/docker/Dockerfile.orig .cqfd/docker/Dockerfile
 jtest_log info "restore container"

--- a/tests/06-cqfd_release
+++ b/tests/06-cqfd_release
@@ -9,9 +9,6 @@ cqfd="$TDIR/.cqfd/cqfd"
 
 cd "$TDIR/" || exit 1
 
-cqfdrc_old=$(mktemp)
-cp -f .cqfdrc "$cqfdrc_old"
-
 ################################################################################
 # The first invocation has no 'files' parameter defined,
 # hence it should fail
@@ -27,6 +24,7 @@ fi
 # Adding a files section should help
 ################################################################################
 rel_files="a/cqfd_a.txt a/b/c/cqfd_c.txt a/b/cqfd_b.txt"
+cp -f .cqfdrc .cqfdrc.old
 echo "files=\"$rel_files\"" >>.cqfdrc
 jtest_prepare "cqfd release now with a files parameter"
 if "$cqfd" release; then
@@ -310,4 +308,4 @@ fi
 
 # cleanup
 rm -f "tmp.$$" "cqfd-$CTEST.tar.xz"
-mv -f "$cqfdrc_old" .cqfdrc
+mv -f .cqfdrc.old .cqfdrc

--- a/tests/06-cqfd_release
+++ b/tests/06-cqfd_release
@@ -107,12 +107,12 @@ if ! "$cqfd" release; then
 	jtest_log fatal "cqfd release failed"
 	result="fail"
 fi
-tmp_dir=$(mktemp -d)
-if ! tar xf cqfd-test.tar.xz -C "$tmp_dir"; then
+mkdir "$TDIR/output"
+if ! tar xf cqfd-test.tar.xz -C "$TDIR/output"; then
 	jtest_log fatal "tar failed"
 	result="fail"
 fi
-if [ -L "$tmp_dir"/link.txt ] || ! diff "$tmp_dir"/a/cqfd_a.txt "$tmp_dir"/link.txt; then
+if [ -L "$TDIR/output/link.txt" ] || ! diff "$TDIR/output/a/cqfd_a.txt" "$TDIR/output/link.txt"; then
 	jtest_log fatal "link.txt is not a symlink or differs from cqfd_a.txt"
 	result="fail"
 fi
@@ -124,8 +124,9 @@ sed -i '/tar_options=/d' .cqfdrc
 sed -i '/files=/d' .cqfdrc
 echo "files=\"$rel_files\"" >>.cqfdrc
 
+# cleanup
 rm -f cqfd-test.tar.xz
-rm -rf "$tmp_dir"
+rm -rf "$TDIR/output"
 
 ################################################################################
 # Now test adding an archive filename template to the config

--- a/tests/09-cqfd-pts
+++ b/tests/09-cqfd-pts
@@ -9,8 +9,7 @@ cqfd="$TDIR/.cqfd/cqfd"
 
 cd "$TDIR/" || exit 1
 
-cqfdrc_old=$(mktemp)
-cp -f .cqfdrc "$cqfdrc_old"
+cp -f .cqfdrc .cqfdrc.old
 sed -i -e "/\[build\]/,/^$/s/^command=.*$/command='tty || true'/" .cqfdrc
 
 jtest_prepare "cqfd without redirection should allocate a tty"
@@ -56,4 +55,5 @@ else
 fi
 rm out err
 
-mv -f "$cqfdrc_old" .cqfdrc
+# restore initial .cqfdrc
+mv -f .cqfdrc.old .cqfdrc

--- a/tests/10-cqfd_doutofd
+++ b/tests/10-cqfd_doutofd
@@ -10,15 +10,12 @@ cqfd_docker="${CQFD_DOCKER:-docker}"
 
 cd "$TDIR/" || exit 1
 
-cqfdrc_old=$(mktemp)
-cp -f .cqfdrc "$cqfdrc_old"
-dockerfile_old=$(mktemp)
-cp -f .cqfd/docker/Dockerfile "$dockerfile_old"
-
 jtest_prepare "cqfd run docker using host docker daemon"
 if [ "$cqfd_docker" != "docker" ] || ! getent group docker | grep -q "$USER"; then
 	jtest_result skip
 else
+	cp -f .cqfdrc .cqfdrc.old
+	cp -f .cqfd/docker/Dockerfile .cqfd/docker/Dockerfile.old
 	cp -f .cqfd/docker/Dockerfile.doutofd .cqfd/docker/Dockerfile
 	sed -i -e "/\[build\]/,/^$/s,^command=.*$,command='docker run --rm -ti ubuntu:24.04 cat /etc/os-release'," .cqfdrc
 
@@ -27,7 +24,7 @@ else
 	else
 		jtest_result fail
 	fi
+	# restore .cqfdrc and Dockerfile
+	mv -f .cqfdrc.old .cqfdrc
+	mv -f .cqfd/docker/Dockerfile.old .cqfd/docker/Dockerfile
 fi
-
-mv -f "$cqfdrc_old" .cqfdrc
-mv -f "$dockerfile_old" .cqfd/docker/Dockerfile


### PR DESCRIPTION
mktemp creates a temporary files and directories to /tmp/tmp.XXXXXX if TEMPLATE is not given and if TMPDIR is unset.

The tests are run in a mktemp directory already[1][2], and that directory is removed at the end of tests[3] (if the tests are not interrupted). The directory is pointed by "$TDIR".

Thus, additional temporary files and directories can be created in that directory to avoid having multiple places to clean up during a test or after the tests. It pollutes even more the temporary directory of the system if files and directories are left uncleaned.

This removes the use of mktemp to copy temporary files and directories directly in the existing temporary directory "$TDIR" to avoid polluting the temporary directory of the system if the tests are interrupted.

[1]: https://github.com/savoirfairelinux/cqfd/blob/v5.7.0/tests/Makefile#L14
[2]: https://github.com/savoirfairelinux/cqfd/blob/v5.7.0/tests/Makefile#L17
[3]: https://github.com/savoirfairelinux/cqfd/blob/v5.7.0/tests/Makefile#L29-L31