### PR TITLE
bash-completion: complete only directories on -C and -d

### DIFF
--- a/bash-completion
+++ b/bash-completion
@@ -29,7 +29,11 @@ _cqfd() {
 	_init_completion || return
 
 	case $prev in
-	-C|-d|-f)
+	-C|-d)
+		_filedir -d
+		return
+		;;
+	-f)
 		_filedir
 		return
 		;;


### PR DESCRIPTION
This completes only directories on options -C and -d.