### PR TITLE
cqfd: load_config: group flavor to build variables

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -804,6 +804,8 @@ load_config() {
 			unset 'flavors[$i]'
 		fi
 	done
+	# shellcheck disable=SC2178
+	flavors="${flavors[*]}"
 
 	# load the [project] section
 	if ! cfg_section_project 2>/dev/null; then
@@ -833,8 +835,6 @@ load_config() {
 		die ".cqfdrc: Missing build section!"
 	fi
 
-	build_flavors="${flavors[*]}"
-
 	# build parameters may be overriden by a flavor defined in the
 	# build section's 'flavors' parameter.
 	local flavor="$1"
@@ -845,6 +845,8 @@ load_config() {
 		fi
 	fi
 
+	# shellcheck disable=SC2128
+	build_flavors="$flavors"
 	# shellcheck disable=SC2154
 	build_command="$command"
 	# shellcheck disable=SC2154

--- a/cqfd
+++ b/cqfd
@@ -796,6 +796,7 @@ load_config() {
 	# functions reported by the builtin:
 	#  - the cfg_section_ prefix is stripped
 	#  - the build and project sections are stripped
+	local flavors
 	mapfile -t flavors < <(compgen -A function -X '!cfg_section_*')
 	flavors=("${flavors[@]/cfg_section_/}")
 	for i in "${!flavors[@]}"; do


### PR DESCRIPTION
This groups the flavor build variables to the other build variables.