### PR TITLE
bash-completion: fix completion for version short option

### DIFF
--- a/bash-completion
+++ b/bash-completion
@@ -95,7 +95,7 @@ _cqfd() {
 		return
 	fi
 
-	local opts="-C -w -d -f -b -q --release -V --version -h --help"
+	local opts="-C -w -d -f -b -q --release -v --version -h --help"
 	if [[ "$cur" == -* ]]; then
 		COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 		return


### PR DESCRIPTION
The short option for version is -v (in lowercase).

This fixes the completion for the short option version -v.