### PR TITLE
cqfd: docker_run: use workdir docker-run option

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -533,14 +533,13 @@ docker_run() {
 		args+=(--volume /var/run/docker.sock:/var/run/docker.sock)
 	fi
 
-	# Bind mount the project directory
+	# Bind mount the project directory set it as working directory
 	local workdir
 	if ! workdir="$(realpath "$build_workdir")" ||
 	   [ ! -d "$workdir" ]; then
 		die "$build_workdir: Missing or not a directory!"
 	fi
-	cqfd_user_cwd="$workdir"
-	args+=(--volume "$cqfd_user_cwd:$cqfd_user_cwd")
+	args+=(--volume "$workdir:$workdir" --workdir "$workdir")
 
 	# Create and bind mount the entrypoint
 	tmp_entrypoint=$(mktemp /tmp/cqfd-entrypoint.XXXXXX)
@@ -660,9 +659,6 @@ test_cmd() {
 test_su_session_command() {
 	su --session-command true >/dev/null 2>&1
 }
-
-# Change to working directory
-cd "$cqfd_user_cwd"
 
 # Check if privileges are already dropped
 uid="\$(id -u)"

--- a/tests/05-cqfd_run_dockerfile
+++ b/tests/05-cqfd_run_dockerfile
@@ -2,6 +2,8 @@
 #
 # validate the behavior of run with Dockerfile
 
+set -o pipefail
+
 . "$(dirname "$0")/jtest.inc" "$1"
 cqfd="$TDIR/.cqfd/cqfd"
 
@@ -15,6 +17,16 @@ cat <<EOF >>.cqfd/docker/Dockerfile
 ENTRYPOINT ["false"]
 EOF
 if "$cqfd" init && "$cqfd" run; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+jtest_prepare "cqfd run using a Dockerfile with workdir should success"
+cat <<EOF >>.cqfd/docker/Dockerfile
+WORKDIR /mnt
+EOF
+if "$cqfd" init && "$cqfd" run pwd | grep -q "$PWD"; then
 	jtest_result pass
 else
 	jtest_result fail


### PR DESCRIPTION
This uses the workdir docker-run option instead of changing directory in the entrypoint.