### PR TITLE
Fix "cqfd: build documentation using cqfd"

### DIFF
--- a/.cqfdrc
+++ b/.cqfdrc
@@ -8,9 +8,9 @@ files='CHANGELOG.md \
        AUTHORS \
        LICENSE \
        README.md \
-       samples/Dockerfile.trusty.nodejs5x \
+       samples/Dockerfile.focalFossa.nodejs20x \
        samples/dot-cqfdrc \
-       samples/Dockerfile.trusty.android23 \
+       samples/Dockerfile.focalFossa.android34 \
        cqfdrc.5.gz \
        cqfd.1.gz \
        cqfd'


### PR DESCRIPTION
This fixes commit fd569e09e9fae46429e872ba0be5dbcf03030be8.

See commit 667144062c9a0363c7114124e853e5c681c2824f.