### PR TITLE
Fix "cqfd: exec, shell: allows to release"

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -936,9 +936,6 @@ load_config() {
 }
 
 has_to_release=false
-if [ "$#" -eq 0 ]; then
-	load_config
-fi
 while [ $# -gt 0 ]; do
 	case "$1" in
 	help|-h|--help)
@@ -1006,6 +1003,7 @@ while [ $# -gt 0 ]; do
 		has_to_release=true
 		;;
 	exec)
+		cqfd_command="$1"
 		shift
 		if [ "$#" -lt 1 ]; then
 			usage
@@ -1016,6 +1014,7 @@ while [ $# -gt 0 ]; do
 		break
 		;;
 	run|release)
+		cqfd_command="$1"
 		if [ "$1" = "release" ]; then
 			has_to_release=true
 		fi
@@ -1049,6 +1048,7 @@ while [ $# -gt 0 ]; do
 		break
 		;;
 	sh|ash|dash|bash|ksh|zsh|csh|tcsh|fish|shell)
+		cqfd_command="$1"
 		if [ "$1" != "shell" ]; then
 			cqfd_shell="$1"
 		fi
@@ -1067,6 +1067,10 @@ while [ $# -gt 0 ]; do
 	esac
 	shift
 done
+
+if [ -z "$cqfd_command" ]; then
+	load_config "$flavor"
+fi
 
 if [ -z "$build_command" ]; then
 	die ".cqfdrc: Missing or empty build.command property!"

--- a/tests/05-cqfd_run_flavor
+++ b/tests/05-cqfd_run_flavor
@@ -16,6 +16,10 @@ for i in 0 1; do
 
 	if [ "$i" = "0" ]; then
 		test_file=$flavor
+		jtest_prepare "cqfd build cmd for '$flavor' flavor"
+		"$cqfd" -b "$flavor"
+	elif [ "$i" = "1" ]; then
+		test_file=$flavor
 		jtest_prepare "cqfd run build cmd for '$flavor' flavor"
 		"$cqfd" -b "$flavor" run
 	else

--- a/tests/06-cqfd_release
+++ b/tests/06-cqfd_release
@@ -306,7 +306,29 @@ if ! grep -q '^.cqfdrc$' "tmp.$$" ||
 else
 	jtest_result pass
 fi
+rm -f "cqfd-$CTEST.tar.xz"
+rm -f "tmp.$$"
 
-# cleanup
-rm -f "tmp.$$" "cqfd-$CTEST.tar.xz"
+################################################################################
+# Using option --release should succeed
+################################################################################
+# shellcheck disable=SC2016
+sed -i -e 's!^archive=.*$!archive=cqfd-$CTEST.tar.xz!' .cqfdrc
+sed -i -e 's!^files=.*$!files=".cqfd/cqfd"!' .cqfdrc
+jtest_prepare "cqfd release with option --release"
+if "$cqfd" --release; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+jtest_prepare "default orgname-project.tar archive is generated"
+if tar tf "cqfd-$CTEST.tar.xz" &>/dev/null; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+rm -f "cqfd-$CTEST.tar.xz"
+
+# restore initial .cqfdrc
 mv -f .cqfdrc.orig .cqfdrc


### PR DESCRIPTION
This fixes commit 34362fd872a829258e8f1062ea99b5b5392b0718.

This loads the configuration file .cqfdrc if no cqfd command is set, but option are given.

Fixes:

	$ cqfd --verbose
	cqfd: fatal: .cqfdrc: Missing or empty build.command property!

	$ cqfd --release
	cqfd: fatal: .cqfdrc: Missing or empty build.command property!

	$ cqfd -b foo
	cqfd: fatal: .cqfdrc: Missing or empty build.command property!

	$ cqfd -C .
	cqfd: fatal: .cqfdrc: Missing or empty build.command property!