### PR TITLE
cqfd: depreciate distro property

### DIFF
--- a/.cqfdrc
+++ b/.cqfdrc
@@ -16,15 +16,15 @@ files='CHANGELOG.md \
        cqfd'
 
 [deb]
-distro='deb'
+dockerfile='.cqfd/deb/Dockerfile'
 docker_run_args="--volume $HOME:$HOME"
 command='sh make-deb.sh'
 
 [pkg]
-distro='pkg'
+dockerfile='.cqfd/pkg/Dockerfile'
 command='sh make-pkg.sh'
 
 [rpm]
-distro='rpm'
+dockerfile='.cqfd/rpm/Dockerfile'
 docker_run_args="--volume $PWD/rpmbuild:$HOME/rpmbuild --volume $PWD/cqfd6.spec:$HOME/rpmbuild/SPECS/cqfd6.spec"
 command='sh make-rpm.sh'

--- a/cqfd
+++ b/cqfd
@@ -912,6 +912,12 @@ load_config() {
 		cqfd_platform="$native"
 	fi
 
+	# warn if using legacy variable distro
+	if [ -n "$build_distro" ]; then
+		warn "distro is deprecated, use dockerfile to set path to" \
+		     "the Dockerfile."
+	fi
+
 	# warn if using legacy variable custom_img_name
 	if [ -n "$project_custom_img_name" ]; then
 		warn "custom_img_name is deprecated, use either tag to name" \


### PR DESCRIPTION
This adds a warning if distro is used in .cqfdrc telling to use dockerfile= instead.

Note: This updates the .cqfdrc by replacing the distro= properties by dockerfile=.