### PR TITLE
cqfd: default to cqfd exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ emulation.
 cqfd6 is a fork of cqfd fixing several broken things in the upstream project.
 It depreciates the former CLI to modernize it to something much more simple and
 much more common such as the CLI of `sudo`. Moreover, the project need a new
-name, remembering its roots.
+name, remembering its roots. Meanwhile, cqfd6 is for *CQFD Sudo Interface
+eXperimentation*.
 
 # Using cqfd
 
@@ -36,7 +37,7 @@ Just follow these steps:
 * Go into your project's directory
 * Create a `.cqfdrc` file
 * Create a Dockerfile and save it as `.cqfd/docker/Dockerfile`
-* Run `cqfd init`
+* Run `cqfd --init`
 
 Examples are available in the `samples/` directory.
 
@@ -45,7 +46,7 @@ build environment for your project.
 
 > ⚠️ Warning
 >
-> Running `cqfd init` creates and names a new Docker image each
+> Running `cqfd --init` creates and names a new Docker image each
 > time the Dockerfile is modified, which may lead to a large number of
 > unused images that are not automatically purged.
 
@@ -61,15 +62,15 @@ default build command as configured in `.cqfdrc`, use:
 Alternatively, you may want to specify a single custom command to be
 executed from inside the build container.
 
-    $ cqfd exec make clean
+    $ cqfd --exec make clean
 
 Or custom commands composed with shell grammar:
 
-    $ cqfd shell -c "make linux-dirclean && make foobar-dirclean"
+    $ cqfd --shell -c "make linux-dirclean && make foobar-dirclean"
 
 Or run a shell script with arguments:
 
-    $ cqfd shell ./build.sh debug
+    $ cqfd --shell ./build.sh debug
 
 When `cqfd` is running, the current directory is mounted by Docker
 as a volume. As a result, all the build artefacts generated inside the
@@ -168,7 +169,7 @@ image=ubuntu:16:04
 ```
 
 Note: When using a prebuilt image from a repository using `custom_img_name` or
-`image`, the `cqfd init` is **not** necessary as no image has to be built.
+`image`, the `cqfd --init` is **not** necessary as no image has to be built.
 Furthermore, when using `image` the `Dockerfile` is **not** necessary as well.
 
 ### The [build] section
@@ -340,11 +341,11 @@ the cqfd group in the container.
 
 ### Appending to the build command
 
-The `-c` option set immediately after the command run allows appending the
-command of a cqfd run for temporary developments:
+The `-c` option set immediately after the command --run allows appending the
+command of a cqfd --run for temporary developments:
 
-    $ cqfd --build centos7 run -c "clean"
-    $ cqfd --build centos7 run -c "TRACING=1"
+    $ cqfd --build centos7 --run -c "clean"
+    $ cqfd --build centos7 --run -c "TRACING=1"
 
 ### Running a shell in the container
 
@@ -354,18 +355,18 @@ the `CQFD_SHELL` environment variable.
 
 Example:
 
-    fred@host:~/project$ cqfd shell
+    fred@host:~/project$ cqfd --shell
     fred@container:~/project$
 
 ### Use cqfd as an interpreter for shell script
 
-You can use the `shell` command to write a shell script and run it in your
+You can use the `--shell` command to write a shell script and run it in your
 defined container.
 
 Example:
 
     fred@host:~/project$ cat get-container-pretty-name.sh
-    #!/usr/bin/env -S cqfd shell
+    #!/usr/bin/env -S cqfd --shell
     if ! test -e /.dockerenv; then
         exit 1
     fi
@@ -376,12 +377,12 @@ Example:
 
 ### Use cqfd as a standard shell for binaries
 
-You can even use the `shell` command to use it as a standard `$SHELL` so
+You can even use the `--shell` command to use it as a standard `$SHELL` so
 binaries honoring that variable run shell commands in your defined container.
 
 Example:
 
-    fred@host:~/project$ make SHELL="cqfd shell"
+    fred@host:~/project$ make SHELL="cqfd --shell"
     Available make targets:
        help:      This help message
        install:   Install script, doc and resources
@@ -404,11 +405,11 @@ First, specify the desired platform in the `Dockerfile`, as shown below:
 
 Then, initialize the image:
 
-    $ cqfd init
+    $ cqfd --init
 
 Finally, test the build container:
 
-    $ cqfd exec uname -m
+    $ cqfd --exec uname -m
     aarch64
 
 Additionally, cqfd supports the option `--platform TARGET`, the environment
@@ -417,13 +418,13 @@ platform dynamically.
 
 Examples:
 
-    $ cqfd --platform linux/arm64 init
-    $ cqfd --platform linux/arm64 exec uname -m
+    $ cqfd --platform linux/arm64 --init
+    $ cqfd --platform linux/arm64 --exec uname -m
     aarch64
 
     $ export CQFD_PLATFORM="linux/arm64"
-    $ cqfd init
-    $ cqfd exec uname -m
+    $ cqfd --init
+    $ cqfd --exec uname -m
     aarch64
 
     $ cat .cqfdrc
@@ -436,10 +437,10 @@ Examples:
 
     [build]
     command='uname -a'
-    $ cqfd init
-    $ cqfd exec uname -m
+    $ cqfd --init
+    $ cqfd --exec uname -m
     x86_64
-    $ cqfd --build arm64 exec uname -m
+    $ cqfd --build arm64 --exec uname -m
     aarch64
 
 ### Key files and directories

--- a/bash-completion
+++ b/bash-completion
@@ -19,10 +19,22 @@ if [ -z "$BASH_VERSION" ]; then
 	_init_completion() {
 		:
 	}
-	_get_first_arg() {
-		:
-	}
 fi
+
+# This function returns the command
+# @param $1 chars  Characters out of $COMP_WORDBREAKS which should
+#     NOT be considered word breaks. See __reassemble_comp_words_by_ref.
+_get_cmd() {
+	local i
+
+	cmd=
+	for ((i = 1; i < COMP_CWORD; i++)); do
+		if [[ ${COMP_WORDS[i]} =~ --(init|deinit|ls|gc|flavors|exec|run|release|shell|-v|version|-h|help) ]]; then
+			cmd=${COMP_WORDS[i]}
+			break
+		fi
+	done
+}
 
 _cqfd() {
 	local cur prev words cword
@@ -58,16 +70,16 @@ _cqfd() {
 		fi
 		return
 		;;
-	init|deinit|ls|gc|flavors|release|-v|version|-h|help)
+	--init|--deinit|--ls|--gc|--flavors|-v|--version|-h|--help)
 		return
 		;;
 	esac
 
-	local arg=
-	_get_first_arg
-	if [[ "$arg" =~ ^(exec|run)$ ]]; then
+	local cmd=
+	_get_cmd
+	if [[ "$cmd" =~ ^--(exec|run)$ ]]; then
 		for (( i=1; i <= cword; i++ )); do
-			if [[ ${words[i]} == "$arg" ]]; then
+			if [[ ${words[i]} == "$cmd" ]]; then
 				if [[ $((i+1)) -eq $cword ]]; then
 					break
 				elif [[ ${words[i+1]} == -c ]]; then
@@ -78,15 +90,15 @@ _cqfd() {
 			fi
 		done
 
-		if [[ "$arg" == exec ]]; then
+		if [[ "$cmd" == --exec ]]; then
 			COMPREPLY=( $(compgen -c -- "$cur") )
 		else
 			COMPREPLY=( $(compgen -c -W "-c" -- "$cur") )
 		fi
 		return
-	elif [[ "$arg" =~ ^(shell|sh|ash|dash|bash|ksh|zsh|csh|tcsh|fish)$ ]]; then
+	elif [[ "$cmd" == --shell ]]; then
 		for (( i=1; i <= cword; i++ )); do
-			if [[ ${words[i]} == "$arg" ]]; then
+			if [[ ${words[i]} == "$cmd" ]]; then
 				((i++))
 				break
 			fi
@@ -99,14 +111,8 @@ _cqfd() {
 		return
 	fi
 
-	local opts="-C --directory -w --working-directory -d --cqfd-directory -f --cqfdrc-file -b --build -q --quiet --reinit --release --platform -v --version -h --help"
-	if [[ "$cur" == -* ]]; then
-		COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
-		return
-	fi
-
-	local shells="sh ash dash bash ksh zsh csh tcsh fish"
-	local cmds="init deinit ls gc flavors exec run release shell version help"
-	COMPREPLY=( $(compgen -W "$shells $cmds $opts" -- "$cur") )
+	local opts="-C --directory -w --working-directory -d --cqfd-directory -f --cqfdrc-file -b --build -q --quiet --reinit --release --platform"
+	local cmds="--init --deinit --ls --gc --flavors --exec --run --shell -v --version -h --help"
+	COMPREPLY=( $(compgen -W "$cmds $opts" -- "$cur") )
 } &&
 complete -F _cqfd cqfd linux-amd64-cqfd linux-arm-cqfd linux-arm64-cqfd linux-ppc64le-cqfd linux-riscv64-cqfd linux-s390x-cqfd cqfd6

--- a/cqfd
+++ b/cqfd
@@ -35,7 +35,14 @@ cqfd_cachedir="${CQFD_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/cqfd}"
 # stdout: the usage
 usage() {
 	cat <<EOF
-Usage: $PROGNAME [OPTIONS] [COMMAND] [COMMAND OPTIONS] [ARGUMENTS]
+Usage: $PROGNAME [OPTIONS] --init|--deinit
+       $PROGNAME [OPTIONS] --ls|--gc
+       $PROGNAME [OPTIONS] --exec COMMAND [ARGUMENTS]
+       $PROGNAME [OPTIONS] --flavors
+       $PROGNAME [OPTIONS] --run [COMMAND_STRING]
+       $PROGNAME [OPTIONS] --run -c ARGUMENT_STRING
+       $PROGNAME [OPTIONS] --shell [SHELL_ARGUMENTS]
+       $PROGNAME [OPTIONS] [--] [PROGRAM] [ARGUMENTS]
 
 Options:
     --reinit             Reinitialize build container.
@@ -58,17 +65,14 @@ Options:
     -h or --help         Show this help text.
 
 Commands:
-    init                 Initialize project build container.
-    deinit               Deinitialize project build container.
-    ls                   List build containers.
-    gc                   Cleanup unused build containers.
-    exec cmd [args]      Run command inside build container.
-    flavors              List flavors from config file to stdout.
-    run [cmdstring]      Run command string inside build container.
-    release              Release software.
-    shell [shargs]       Run shell command inside build container.
-    version              Show version.
-    help                 Show this help text.
+    --init               Initialize project build container.
+    --deinit             Deinitialize project build container.
+    --ls                 List build containers.
+    --gc                 Cleanup unused build containers.
+    --exec cmd [args]    Run command inside build container.
+    --flavors            List flavors from config file to stdout.
+    --run [cmdstring]    Run command string inside build container.
+    --shell [shargs]     Run shell command inside build container.
 
     By default, the 'run' command is assumed, with the default
     command string configured in your .cqfdrc (see build.command).
@@ -439,7 +443,7 @@ docker_run() {
 				die "Custom image couldn't be pulled, please build/upload it first"
 			fi
 		else
-			die "The docker image doesn't exist, launch 'cqfd init' to create it"
+			die "The docker image doesn't exist, launch 'cqfd --init' to create it"
 		fi
 	fi
 
@@ -1041,7 +1045,7 @@ while [ $# -gt 0 ]; do
 		export CQFD_DEBUG=true
 		export BUILDKIT_PROGRESS=plain
 		;;
-	init)
+	init|--init)
 		shift
 		if [ "$#" -gt 0 ]; then
 			usage
@@ -1051,7 +1055,7 @@ while [ $# -gt 0 ]; do
 		docker_pull_or_build
 		exit
 		;;
-	deinit)
+	deinit|--deinit)
 		shift
 		if [ "$#" -gt 0 ]; then
 			usage
@@ -1061,7 +1065,7 @@ while [ $# -gt 0 ]; do
 		docker_rmi
 		exit
 		;;
-	ls)
+	ls|--ls)
 		shift
 		if [ "$#" -gt 0 ]; then
 			usage
@@ -1071,7 +1075,7 @@ while [ $# -gt 0 ]; do
 		list
 		exit
 		;;
-	gc)
+	gc|--gc)
 		shift
 		if [ "$#" -gt 0 ]; then
 			usage
@@ -1081,7 +1085,7 @@ while [ $# -gt 0 ]; do
 		prune
 		exit
 		;;
-	flavors)
+	flavors|--flavors)
 		shift
 		if [ "$#" -gt 0 ]; then
 			usage
@@ -1125,7 +1129,7 @@ while [ $# -gt 0 ]; do
 		shift
 		CQFD_PLATFORM="$1"
 		;;
-	exec)
+	exec|--exec)
 		cqfd_command="$1"
 		shift
 		if [ "$#" -lt 1 ]; then
@@ -1136,7 +1140,7 @@ while [ $# -gt 0 ]; do
 		build_command="${*@Q}"
 		break
 		;;
-	run|release)
+	run|--run|release)
 		cqfd_command="$1"
 		shift
 
@@ -1192,7 +1196,7 @@ while [ $# -gt 0 ]; do
 		fi
 		break
 		;;
-	sh|ash|dash|bash|ksh|zsh|csh|tcsh|fish|shell)
+	shell|--shell)
 		cqfd_command="$1"
 		if [ "$1" != "shell" ]; then
 			cqfd_shell="$1"
@@ -1205,9 +1209,20 @@ while [ $# -gt 0 ]; do
 		fi
 		break
 		;;
-	*)
+	--)
+		shift
+		break
+		;;
+	-*)
 		usage
-		die "$1: Invalid command!"
+		die "$1: Invalid option!"
+		;;
+	*)
+		# Run command
+		cqfd_command="exec"
+		load_config "$flavor"
+		build_command="${*@Q}"
+		break
 		;;
 	esac
 	shift

--- a/cqfd.1.adoc
+++ b/cqfd.1.adoc
@@ -12,7 +12,14 @@ cqfd - a tool to wrap commands in controlled Docker containers using docker.
 
 == SYNOPSIS
 
-*cqfd* [OPTIONS] [COMMAND] [COMMAND_OPTIONS] [COMMAND_ARGUMENTS]
+*cqfd* [OPTIONS] --init|--deinit
+*cqfd* [OPTIONS] --ls|--gc
+*cqfd* [OPTIONS] --exec COMMAND [ARGUMENTS]
+*cqfd* [OPTIONS] --flavors
+*cqfd* [OPTIONS] --run [COMMAND_STRING]
+*cqfd* [OPTIONS] --run -c ARGUMENT_STRING
+*cqfd* [OPTIONS] --shell [SHELL_ARGUMENTS]
+*cqfd* [OPTIONS] [--] [PROGRAM] [ARGUMENTS]
 
 == DESCRIPTION
 
@@ -25,38 +32,29 @@ Linux distribution.
 
 == COMMANDS
 
-*init*::
+*--init*::
 	Initialize project build container.
 
-*deinit*::
+*--deinit*::
 	Deinitialize project build container.
 
-*list*::
+*--list*::
 	List build containers.
 
-*gc*::
+*--gc*::
 	Cleanup unused build containers.
 
-*exec PROGRAM [ARGUMENTS]*::
+*--exec PROGRAM [ARGUMENTS]*::
 	Run command inside build container.
 
-*flavors*::
+*--flavors*::
 	List flavors from config file to stdout.
 
-*run [COMMAND_STRING]*::
+*--run [COMMAND_STRING]*::
 	Run command string inside build container.
-
-*release*::
-	Release software.
 
 *--shell [SH_ARGUMENTS]*::
 	Run shell command inside build container.
-
-*version*::
-	Show version.
-
-*help*::
-	Show this help text.
 
 By default, the _run_ command is assumed, with the default command string
 configured in your _.cqfdrc_ (see build.command).


### PR DESCRIPTION
In order to have cqfd to run similarly to known tools, such as sudo, the cqfd commands have been optionized and the default command is now "exec".

[gportay: remain backward compatible with former commands
          default to exec instead of run
          update usage and bash-completion script]