### PR TITLE
bash-completion: stop completion if command has no arguments

### DIFF
--- a/bash-completion
+++ b/bash-completion
@@ -58,7 +58,7 @@ _cqfd() {
 		fi
 		return
 		;;
-	init|flavors|release|help)
+	init|flavors|release|-h|help)
 		return
 		;;
 	esac

--- a/bash-completion
+++ b/bash-completion
@@ -58,7 +58,7 @@ _cqfd() {
 		fi
 		return
 		;;
-	init|deinit|flavors|release|-v|version|-h|help)
+	init|deinit|ls|flavors|release|-v|version|-h|help)
 		return
 		;;
 	esac

--- a/bash-completion
+++ b/bash-completion
@@ -58,7 +58,7 @@ _cqfd() {
 		fi
 		return
 		;;
-	init|deinit|ls|flavors|release|-v|version|-h|help)
+	init|deinit|ls|gc|flavors|release|-v|version|-h|help)
 		return
 		;;
 	esac

--- a/bash-completion
+++ b/bash-completion
@@ -58,7 +58,7 @@ _cqfd() {
 		fi
 		return
 		;;
-	init|flavors|release|-h|help)
+	init|flavors|release|-v|version|-h|help)
 		return
 		;;
 	esac

--- a/bash-completion
+++ b/bash-completion
@@ -58,7 +58,7 @@ _cqfd() {
 		fi
 		return
 		;;
-	init|flavors|release|-v|version|-h|help)
+	init|deinit|flavors|release|-v|version|-h|help)
 		return
 		;;
 	esac


### PR DESCRIPTION
This stops completion if the command takes no arguments.