### PR TITLE
cqfd: shorten cqfd_user_ prefix to cqfd_

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -24,7 +24,7 @@ set -o pipefail
 PROGNAME=$(basename "$0")
 VERSION=6
 cqfd_user="${USER:-builder}"
-cqfd_user_home="${HOME:-/home/$cqfd_user}"
+cqfd_home="${HOME:-/home/$cqfd_user}"
 cqfd_shell="${CQFD_SHELL:-/bin/sh}"
 # shellcheck disable=SC2162
 read -a cqfd_docker <<<"${CQFD_DOCKER:-docker}"
@@ -522,11 +522,11 @@ docker_run() {
 	# via CQFD_EXTRA_RUN_ARGS or docker_run_args
 	if ! echo "$CQFD_EXTRA_RUN_ARGS $build_docker_run_args" |
 	     grep -qE "(-e[[:blank:]]*|--env[[:blank:]]+)HOME="; then
-		args+=(--env "HOME=$cqfd_user_home")
+		args+=(--env "HOME=$cqfd_home")
 	fi
 
 	if [ "$CQFD_NO_USER_SSH_CONFIG" != true ]; then
-		args+=(--volume "$cqfd_user_home/.ssh:$cqfd_user_home/.ssh")
+		args+=(--volume "$cqfd_home/.ssh:$cqfd_home/.ssh")
 	fi
 
 	if [ "$CQFD_NO_SSH_CONFIG" != true ]; then
@@ -534,12 +534,12 @@ docker_run() {
 	fi
 
 	if [ "$CQFD_NO_SSH_AUTH_SOCK" != true ] && [ "$SSH_AUTH_SOCK" ]; then
-		args+=(--volume "$SSH_AUTH_SOCK:$cqfd_user_home/.sockets/ssh")
-		args+=(--env "SSH_AUTH_SOCK=$cqfd_user_home/.sockets/ssh")
+		args+=(--volume "$SSH_AUTH_SOCK:$cqfd_home/.sockets/ssh")
+		args+=(--env "SSH_AUTH_SOCK=$cqfd_home/.sockets/ssh")
 	fi
 
-	if [ "$CQFD_NO_USER_GIT_CONFIG" != true ] && [ -f "$cqfd_user_home/.gitconfig" ]; then
-		args+=(--mount "type=bind,src=$cqfd_user_home/.gitconfig,dst=$cqfd_user_home/.gitconfig")
+	if [ "$CQFD_NO_USER_GIT_CONFIG" != true ] && [ -f "$cqfd_home/.gitconfig" ]; then
+		args+=(--mount "type=bind,src=$cqfd_home/.gitconfig,dst=$cqfd_home/.gitconfig")
 	fi
 
 	if [ "$CQFD_BIND_DOCKER_SOCK" = true ]; then
@@ -696,9 +696,9 @@ test "\$has_sudo" = 1 || test_su_session_command && has_su_session_command=1
 
 # Add the host's user and group to the container, and adjust ownership
 groupadd -og "${GROUPS[0]}" -f builders
-useradd -s "\$shell" -oN -u "$UID" -g "${GROUPS[0]}" -d "$cqfd_user_home" "$cqfd_user"
-mkdir -p "$cqfd_user_home"
-chown "$UID:${GROUPS[0]}" "$cqfd_user_home"
+useradd -s "\$shell" -oN -u "$UID" -g "${GROUPS[0]}" -d "$cqfd_home" "$cqfd_user"
+mkdir -p "$cqfd_home"
+chown "$UID:${GROUPS[0]}" "$cqfd_home"
 
 # Add specified groups to cqfd_user
 for g in ${CQFD_GROUPS[*]}; do


### PR DESCRIPTION
This renames the internal variable cqfd_user_home to cqfd_home so it matches the name of the environment whom they default from.