### PR TITLE
cqfd: add support for the 'docker' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ should be a member of in the container. You can either use the `group:gid`
 format, or simply specify the `group` name if it exists either in the host or
 inside the docker image.
 
+``docker`` (optional): program used to invoke `docker` client.
+For example, to use docker if not in the docker group, it can be set like:
+```
+docker='sudo docker'
+```
+
 `dockerfile` (optional): the path to the `Dockerfile`. The path is relative to
 the project directory (i.e. the parent directory of `.cqfd`). By default, cqfd
 uses `.cqfd/$distro/Dockerfile` with `distro=docker` if `distro` is unset. For

--- a/cqfd
+++ b/cqfd
@@ -891,6 +891,8 @@ load_config() {
 	# shellcheck disable=SC2154
 	build_platform="$platform"
 	# shellcheck disable=SC2154
+	build_docker="$docker"
+	# shellcheck disable=SC2154
 	build_dockerfile="$dockerfile"
 	# shellcheck disable=SC2154
 	build_docker_build_args="$docker_build_args"
@@ -908,6 +910,12 @@ load_config() {
 	release_transform="$tar_transform"
 	# shellcheck disable=SC2154
 	release_tar_opts="$tar_options"
+
+	# set docker if docker= is set
+	if [ "$build_docker" ]; then
+		# shellcheck disable=SC2162
+		read -a cqfd_docker <<<"$build_docker"
+	fi
 
 	# set native if platform= unspecified
 	cqfd_platform="$build_platform"

--- a/cqfdrc.5.adoc
+++ b/cqfdrc.5.adoc
@@ -90,6 +90,9 @@ line, and right after a section.
 	the _group_ name if it exists either in the host or inside the docker
 	image.
 
+*docker (optional)*::
+	Program used to invoke _docker(1)_ client.
+
 *dockerfile (optional)*::
 	The path to the _Dockerfile_. The path is relative to the project
 	directory (i.e. the parent directory of _.cqfd_). By default, cqfd uses


### PR DESCRIPTION
This adds the option docker= in .cqfdrc to set the docker binary. It allows to run the client using sudo(8) or to select the docker binary (docker, podman).