### PR TITLE
cqfd: depreciate flavors property

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,6 @@ section, referencing other sections named following flavor's name.
 A flavor will typically redefine some keys of the build section: `command`,
 `files`, `archive`, `distro`.
 
-Flavors from a `.cqfdrc` file can be listed using the `flavors` argument.
-
 ### Manual page
 
 For a more thorough description of the `.cqfdrc` configuration file, please

--- a/bash-completion
+++ b/bash-completion
@@ -65,7 +65,7 @@ _cqfd() {
 		done
 
 		if [ -e "$cqfdrc" ]; then
-			flavors=$(cqfd -f $cqfdrc flavors)
+			flavors=$(cqfd -f $cqfdrc --flavors)
 			COMPREPLY=( $(compgen -W "$flavors" -- "$cur") )
 		fi
 		return

--- a/cqfd
+++ b/cqfd
@@ -864,6 +864,12 @@ load_config() {
 	# shellcheck disable=SC2128
 	project_flavors="$flavors"
 
+	# warn if using legacy variable flavors
+	if [ -n "$project_flavors" ]; then
+		warn "flavors is deprecated, the flavors are now automatically" \
+		     "deduced from the flavors sections of .cqfdrc."
+	fi
+
 	# check for [project] org and name properties are set and are not empty
 	if [ -z "$project_org" ] || [ -z "$project_name" ]; then
 		die ".cqfdrc: Missing project.org or project.name properties!"

--- a/cqfdrc.5.adoc
+++ b/cqfdrc.5.adoc
@@ -31,8 +31,8 @@ line, and right after a section.
 
 *flavors (optional)*::
 	The list of build flavors (see below). Each flavor has its own command
-	just like _build.command_. This property is now automatically deduced
-	from the flavors sections of _.cqfdrc_.
+	just like _build.command_. _flavors_ is *deprecated*, the flavors are
+	now automatically deduced from the flavors sections of _.cqfdrc_.
 
 *build_context (optional)*::
 	a directory to pass as the build context to Docker. This should be


### PR DESCRIPTION
This adds a warning if flavors is used in .cqfdrc telling they are
automatically deduced from the flavors sections of .cqfdrc.