### PR TITLE
cqfd: flavors: remove deprecated warning

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -864,12 +864,6 @@ load_config() {
 	# shellcheck disable=SC2128
 	project_flavors="$flavors"
 
-	# warn if using legacy variable flavors
-	if [ -n "$project_flavors" ]; then
-		warn "flavors is deprecated, the flavors are now automatically" \
-		     "deduced from the flavors sections of .cqfdrc."
-	fi
-
 	# check for [project] org and name properties are set and are not empty
 	if [ -z "$project_org" ] || [ -z "$project_name" ]; then
 		die ".cqfdrc: Missing project.org or project.name properties!"


### PR DESCRIPTION
This fixes commit 6e6572ebbf1730a872bf03cff0f9e988f6be6d0a.

Fixes:

	$ grep flavors .cqfdrc
	$ cqfd
	cqfd: warning: flavors is deprecated, the flavors are now automatically deduced from the flavors sections of .cqfdrc.