### PR TITLE
cqfd: run, release: rework deprecated command warnings

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -1261,21 +1261,15 @@ while [ $# -gt 0 ]; do
 		shift
 
 		# Display a warning message if using command run
-		if [ "$cqfd_command" = "run" ]; then
+		if [ "$cqfd_command" = "run" ] && [ "$#" -le 1 ]; then
 			warn_deprecated_command "$cqfd_command" \
 				cqfd "--$cqfd_command" "${*@Q}"
 		fi
 
 		# Display a warning message if using command release
-		if [ "$cqfd_command" = "release" ]; then
-			if [ "$#" -gt 0 ]; then
-				warn "command $cqfd_command shall not support argument(s)."
-				warn_deprecated_command "$cqfd_command" \
-					cqfd "--$cqfd_command" --run "${*@Q}"
-			else
-				warn_deprecated_command "$cqfd_command" \
-					cqfd "--$cqfd_command"
-			fi
+		if [ "$cqfd_command" = "release" ] && [ "$#" -eq 0 ]; then
+			warn_deprecated_command "$cqfd_command" \
+				cqfd "--$cqfd_command"
 		fi
 
 		# Check arguments
@@ -1310,12 +1304,15 @@ while [ $# -gt 0 ]; do
 			build_command+=" $*"
 
 			# Display a warning message if using -c with multiple arguments
-			if [ "$cqfd_command" = "release" ] && [ "$#" -gt 1 ]; then
-				warn "command $cqfd_command -c shall support a single argument."
+			if [ "$cqfd_command" = "release" ]; then
+				warn "command $cqfd_command shall not support argument(s)."
 				warn_deprecated_command "$cqfd_command" \
 					cqfd "--$cqfd_command" --run -c "\"$*\""
 			elif [ "$cqfd_command" = "run" ] && [ "$#" -gt 1 ]; then
 				warn "command $cqfd_command -c shall support a single argument."
+				warn_deprecated_command "$cqfd_command" \
+					cqfd "--$cqfd_command" -c "\"$*\""
+			elif [ "$cqfd_command" = "run" ]; then
 				warn_deprecated_command "$cqfd_command" \
 					cqfd "--$cqfd_command" -c "\"$*\""
 			fi
@@ -1326,11 +1323,23 @@ while [ $# -gt 0 ]; do
 		build_command="$*"
 
 		# Display a warning message if using run with multiple arguments
-		if [ "$#" -ne 1 ]; then
+		if [ "$cqfd_command" = "run" ] && [ "$#" -gt 1 ]; then
 			warn "command $cqfd_command with multiple arguments is ambigous."
 			warn_deprecated_command "$cqfd_command" \
 				cqfd --exec "${*@Q}" or \
 				cqfd --shell -c "\"${*@Q}\""
+		fi
+
+		# Display a warning message if using release with multiple arguments
+		if [ "$cqfd_command" = "release" ] && [ "$#" -gt 1 ]; then
+			warn "command $cqfd_command with multiple arguments is ambigous."
+			warn_deprecated_command "$cqfd_command" \
+				cqfd "--$cqfd_command" --exec "${*@Q}" or \
+				cqfd "--$cqfd_command" --shell -c "\"${*@Q}\""
+		elif [ "$cqfd_command" = "release" ] && [ "$#" -eq 1 ]; then
+			warn "command $cqfd_command shall not support argument(s)."
+			warn_deprecated_command "$cqfd_command" \
+				cqfd "--$cqfd_command" --run "${*@Q}"
 		fi
 		break
 		;;


### PR DESCRIPTION
This reworks the deprecated command warnings to output a single warning.

Fixes:

	$ cqfd run make foo
	cqfd: warning: command run is deprecated, please consider the command instead: cqfd --run 'make' 'foo'
	cqfd: warning: command run with multiple arguments is ambigous.
	cqfd: warning: command run is deprecated, please consider the command instead: cqfd --exec 'make' 'foo' or cqfd --shell -c "'make' 'foo'"

	$ cqfd run -c foo bar
	cqfd: warning: command run is deprecated, please consider the command instead: cqfd --run '-c' 'foo' 'bar'
	cqfd: warning: command run -c shall support a single argument.
	cqfd: warning: command run is deprecated, please consider the command instead: cqfd --run -c "foo bar"

	$ cqfd release make foo
	cqfd: warning: command release shall not support argument(s).
	cqfd: warning: command release is deprecated, please consider the command instead: cqfd --release --run 'make' 'foo'
	cqfd: warning: command release with multiple arguments is ambigous.
	cqfd: warning: command release is deprecated, please consider the command instead: cqfd --exec 'make' 'foo' or cqfd --shell -c "'make' 'foo'"

	$ cqfd release -c foo bar
	cqfd: warning: command release shall not support argument(s).
	cqfd: warning: command release is deprecated, please consider the command instead: cqfd --release --run '-c' 'foo' 'bar'
	cqfd: warning: command release -c shall support a single argument.
	cqfd: warning: command release is deprecated, please consider the command instead: cqfd --release --run -c "foo bar"

Before changes:

	$ cqfd run
	cqfd: warning: command run is deprecated, please consider the command instead: cqfd --run

	$ cqfd run make
	cqfd: warning: command run is deprecated, please consider the command instead: cqfd --run 'make'
	Available make targets:
	   help:      This help message
	   doc:       Generate documentation
	   install:   Install script, doc and resources
	   uninstall: Remove script, doc and resources
	   tests:     Run functional tests
	   clean:     Clean temporary files

	$ cqfd run make foo
	cqfd: warning: command run is deprecated, please consider the command instead: cqfd --run 'make' 'foo'
	cqfd: warning: command run with multiple arguments is ambigous.
	cqfd: warning: command run is deprecated, please consider the command instead: cqfd --exec 'make' 'foo' or cqfd --shell -c "'make' 'foo'"

	$ cqfd run -c foo
	cqfd: warning: command run is deprecated, please consider the command instead: cqfd --run '-c' 'foo'

	$ cqfd run -c foo bar
	cqfd: warning: command run is deprecated, please consider the command instead: cqfd --run '-c' 'foo' 'bar'
	cqfd: warning: command run -c shall support a single argument.
	cqfd: warning: command run is deprecated, please consider the command instead: cqfd --run -c "foo bar"

	$ cqfd release
	cqfd: warning: command release is deprecated, please consider the command instead: cqfd --release

	$ cqfd release make
	cqfd: warning: command release shall not support argument(s).
	cqfd: warning: command release is deprecated, please consider the command instead: cqfd --release --run 'make'
	Available make targets:
	   help:      This help message
	   doc:       Generate documentation
	   install:   Install script, doc and resources
	   uninstall: Remove script, doc and resources
	   tests:     Run functional tests
	   clean:     Clean temporary files

	$ cqfd release make foo
	cqfd: warning: command release shall not support argument(s).
	cqfd: warning: command release is deprecated, please consider the command instead: cqfd --release --run 'make' 'foo'
	cqfd: warning: command release with multiple arguments is ambigous.
	cqfd: warning: command release is deprecated, please consider the command instead: cqfd --exec 'make' 'foo' or cqfd --shell -c "'make' 'foo'"

	$ cqfd release -c make
	cqfd: warning: command release shall not support argument(s).
	cqfd: warning: command release is deprecated, please consider the command instead: cqfd --release --run '-c' 'make'

	$ cqfd release -c foo bar
	cqfd: warning: command release shall not support argument(s).
	cqfd: warning: command release is deprecated, please consider the command instead: cqfd --release --run '-c' 'foo' 'bar'
	cqfd: warning: command release -c shall support a single argument.
	cqfd: warning: command release is deprecated, please consider the command instead: cqfd --release --run -c "foo bar"
After changes:

	$ cqfd run
	cqfd: warning: command run is deprecated, please consider the command instead: cqfd --run

	$ cqfd run make
	cqfd: warning: command run is deprecated, please consider the command instead: cqfd --run 'make'
	Available make targets:
	   help:      This help message
	   doc:       Generate documentation
	   install:   Install script, doc and resources
	   uninstall: Remove script, doc and resources
	   tests:     Run functional tests
	   clean:     Clean temporary files

	$ cqfd run make foo
	cqfd: warning: command run with multiple arguments is ambigous.
	cqfd: warning: command run is deprecated, please consider the command instead: cqfd --exec 'make' 'foo' or cqfd --shell -c "'make' 'foo'"

	$ cqfd run -c foo
	cqfd: warning: command run is deprecated, please consider the command instead: cqfd --run -c "foo"

	$ cqfd run -c foo bar
	cqfd: warning: command run -c shall support a single argument.
	cqfd: warning: command run is deprecated, please consider the command instead: cqfd --run -c "foo bar"

	$ cqfd release
	cqfd: warning: command release is deprecated, please consider the command instead: cqfd --release

	$ cqfd release make
	cqfd: warning: command release shall not support argument(s).
	cqfd: warning: command release is deprecated, please consider the command instead: cqfd --release --run 'make'
	Available make targets:
	   help:      This help message
	   doc:       Generate documentation
	   install:   Install script, doc and resources
	   uninstall: Remove script, doc and resources
	   tests:     Run functional tests
	   clean:     Clean temporary files

	$ cqfd release make foo
	cqfd: warning: command release with multiple arguments is ambigous.
	cqfd: warning: command release is deprecated, please consider the command instead: cqfd --release --exec 'make' 'foo' or cqfd --release --shell -c "'make' 'foo'"

	$ cqfd release -c make
	cqfd: warning: command release shall not support argument(s).
	cqfd: warning: command release is deprecated, please consider the command instead: cqfd --release --run -c "make"

	$ cqfd release -c foo bar
	cqfd: warning: command release shall not support argument(s).
	cqfd: warning: command release is deprecated, please consider the command instead: cqfd --release --run -c "foo bar"