### PR TITLE
cqfd: warning: allow to disable deprecated command messages

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -124,6 +124,11 @@ warn() {
 warn_deprecated_command() {
 	local cmd
 
+	# Deprecated command messages disabled
+	if [ "$CQFD_NO_DEPRECATED_COMMAND_WARNING" = true ]; then
+		return
+	fi
+
 	cmd="$1"
 	shift
 	warn "command $cmd is deprecated," \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,6 @@
 .PHONY: tests check
 
+tests: export CQFD_NO_DEPRECATED_COMMAND_WARNING = true
 tests: CQFD_DOCKER =
 tests: CQFD_EXTRA_RUN_ARGS =
 tests: CQFD_EXTRA_BUILD_ARGS =


### PR DESCRIPTION
This allows to disable deprecated command messages if CQFD_NO_DEPRECATED_COMMAND_WARNING is set to true.