### PR TITLE
Revert "README.md, cqfd.1.adoc: fix typo"

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ refers to [cqfdrc(5)](cqfdrc.5.adoc).
 
 ### Appending extra arguments to the build command
 
-The `-c` option sets immediately after the command `--run` allows appending the
+The `-c` option set immediately after the command `--run` allows appending the
 command of a `cqfd --run` for temporary developments:
 
     $ cqfd --build centos7 --run -c "clean"


### PR DESCRIPTION
This reverts commit a0441995ca91ae490e42fd33ea513af2e7ed925c.